### PR TITLE
Code style improvements (#281)

### DIFF
--- a/opacclient/.idea/codeStyleSettings.xml
+++ b/opacclient/.idea/codeStyleSettings.xml
@@ -31,14 +31,39 @@
           </value>
         </option>
         <option name="RIGHT_MARGIN" value="100" />
+        <option name="HTML_TEXT_WRAP" value="0" />
+        <option name="WRAP_COMMENTS" value="true" />
         <AndroidXmlCodeStyleSettings>
           <option name="USE_CUSTOM_SETTINGS" value="true" />
         </AndroidXmlCodeStyleSettings>
         <XML>
-          <option name="XML_KEEP_LINE_BREAKS" value="false" />
-          <option name="XML_ALIGN_ATTRIBUTES" value="false" />
-          <option name="XML_SPACE_INSIDE_EMPTY_TAG" value="true" />
+          <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
         </XML>
+        <codeStyleSettings language="JAVA">
+          <option name="ALIGN_MULTILINE_CHAINED_METHODS" value="true" />
+          <option name="CALL_PARAMETERS_WRAP" value="1" />
+          <option name="METHOD_PARAMETERS_WRAP" value="1" />
+          <option name="RESOURCE_LIST_WRAP" value="1" />
+          <option name="EXTENDS_LIST_WRAP" value="1" />
+          <option name="THROWS_LIST_WRAP" value="1" />
+          <option name="EXTENDS_KEYWORD_WRAP" value="1" />
+          <option name="THROWS_KEYWORD_WRAP" value="1" />
+          <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
+          <option name="BINARY_OPERATION_WRAP" value="1" />
+          <option name="TERNARY_OPERATION_WRAP" value="1" />
+          <option name="FOR_STATEMENT_WRAP" value="1" />
+          <option name="ARRAY_INITIALIZER_WRAP" value="1" />
+          <option name="ASSIGNMENT_WRAP" value="1" />
+          <option name="ASSERT_STATEMENT_WRAP" value="1" />
+          <option name="IF_BRACE_FORCE" value="1" />
+          <option name="DOWHILE_BRACE_FORCE" value="1" />
+          <option name="WHILE_BRACE_FORCE" value="1" />
+          <option name="FOR_BRACE_FORCE" value="1" />
+          <option name="WRAP_LONG_LINES" value="true" />
+          <option name="PARAMETER_ANNOTATION_WRAP" value="1" />
+          <option name="VARIABLE_ANNOTATION_WRAP" value="1" />
+          <option name="ENUM_CONSTANTS_WRAP" value="1" />
+        </codeStyleSettings>
         <codeStyleSettings language="XML">
           <option name="FORCE_REARRANGE_MODE" value="1" />
           <indentOptions>
@@ -50,7 +75,7 @@
                 <match>
                   <AND>
                     <NAME>xmlns:android</NAME>
-                    <XML_NAMESPACE />
+                    <XML_NAMESPACE>Namespace:</XML_NAMESPACE>
                   </AND>
                 </match>
               </rule>
@@ -58,7 +83,7 @@
                 <match>
                   <AND>
                     <NAME>xmlns:.*</NAME>
-                    <XML_NAMESPACE />
+                    <XML_NAMESPACE>Namespace:</XML_NAMESPACE>
                   </AND>
                 </match>
                 <order>BY_NAME</order>
@@ -170,7 +195,7 @@
         </codeStyleSettings>
       </value>
     </option>
-    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
   </component>
 </project>
 

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/OpacClient.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/OpacClient.java
@@ -79,7 +79,9 @@ import de.geeksfactory.opacclient.searchfields.SearchQuery;
 import de.geeksfactory.opacclient.storage.AccountDataSource;
 import de.geeksfactory.opacclient.storage.StarContentProvider;
 
-@ReportsCrashes(formKey = "", mailTo = "info@opacapp.de", mode = org.acra.ReportingInteractionMode.NOTIFICATION, resToastText = R.string.crash_toast_text)
+@ReportsCrashes(formKey = "", mailTo = "info@opacapp.de",
+        mode = org.acra.ReportingInteractionMode.NOTIFICATION,
+        resToastText = R.string.crash_toast_text)
 public class OpacClient extends Application {
 
     public static final String PREF_SELECTED_ACCOUNT = "selectedAccount";
@@ -110,8 +112,9 @@ public class OpacClient extends Application {
     }
 
     public static Bundle queryToBundle(List<SearchQuery> query) {
-        if (query == null)
+        if (query == null) {
             return null;
+        }
         Bundle b = new Bundle();
         for (SearchQuery q : query) {
             try {
@@ -129,8 +132,9 @@ public class OpacClient extends Application {
     // }
 
     public static List<SearchQuery> bundleToQuery(Bundle bundle) {
-        if (bundle == null)
+        if (bundle == null) {
             return null;
+        }
         List<SearchQuery> query = new ArrayList<SearchQuery>();
         for (String e : bundle.keySet()) {
             try {
@@ -144,8 +148,9 @@ public class OpacClient extends Application {
     }
 
     public static Bundle mapToBundle(Map<String, String> map) {
-        if (map == null)
+        if (map == null) {
             return null;
+        }
         Bundle b = new Bundle();
         for (Entry<String, String> e : map.entrySet()) {
             b.putString(e.getKey(), e.getValue());
@@ -154,8 +159,9 @@ public class OpacClient extends Application {
     }
 
     public static Map<String, String> bundleToMap(Bundle bundle) {
-        if (bundle == null)
+        if (bundle == null) {
             return null;
+        }
         Map<String, String> map = new HashMap<String, String>();
         for (String e : bundle.keySet()) {
             map.put(e, (String) bundle.get(e));
@@ -190,7 +196,8 @@ public class OpacClient extends Application {
     }
 
     public boolean isOnline() {
-        ConnectivityManager connMgr = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
+        ConnectivityManager connMgr =
+                (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
         NetworkInfo networkInfo = connMgr.getActiveNetworkInfo();
         return (networkInfo != null && networkInfo.isConnected());
     }
@@ -199,34 +206,37 @@ public class OpacClient extends Application {
             SocketException, IOException, NotReachableException {
         OpacApi newApiInstance = null;
         if (lib.getApi().equals("bond26") || lib.getApi().equals("bibliotheca"))
-            // Backwardscompatibility
+        // Backwardscompatibility
+        {
             newApiInstance = new Bibliotheca();
-        else if (lib.getApi().equals("oclc2011")
+        } else if (lib.getApi().equals("oclc2011")
                 || lib.getApi().equals("sisis"))
-            // Backwards compatibility
+        // Backwards compatibility
+        {
             newApiInstance = new SISIS();
-        else if (lib.getApi().equals("zones22"))
+        } else if (lib.getApi().equals("zones22")) {
             newApiInstance = new Zones22();
-        else if (lib.getApi().equals("biber1992"))
+        } else if (lib.getApi().equals("biber1992")) {
             newApiInstance = new BiBer1992();
-        else if (lib.getApi().equals("pica"))
+        } else if (lib.getApi().equals("pica")) {
             newApiInstance = new Pica();
-        else if (lib.getApi().equals("iopac"))
+        } else if (lib.getApi().equals("iopac")) {
             newApiInstance = new IOpac();
-        else if (lib.getApi().equals("adis"))
+        } else if (lib.getApi().equals("adis")) {
             newApiInstance = new Adis();
-        else if (lib.getApi().equals("sru"))
+        } else if (lib.getApi().equals("sru")) {
             newApiInstance = new SRU();
-        else if (lib.getApi().equals("webopac.net"))
+        } else if (lib.getApi().equals("webopac.net")) {
             newApiInstance = new WebOpacNet();
-        else if (lib.getApi().equals("winbiap"))
+        } else if (lib.getApi().equals("winbiap")) {
             newApiInstance = new WinBiap();
-        else if (lib.getApi().equals("heidi"))
+        } else if (lib.getApi().equals("heidi")) {
             newApiInstance = new Heidi();
-        else if (lib.getApi().equals("touchpoint"))
+        } else if (lib.getApi().equals("touchpoint")) {
             newApiInstance = new TouchPoint();
-        else
+        } else {
             return null;
+        }
         newApiInstance.init(lib);
         newApiInstance.setStringProvider(new AndroidStringProvider());
         currentLang = getResources().getConfiguration().locale.getLanguage();
@@ -250,7 +260,7 @@ public class OpacClient extends Application {
         if (account != null && api != null) {
             if (sp.getLong(PREF_SELECTED_ACCOUNT, 0) == account.getId()
                     && getResources().getConfiguration().locale.getLanguage()
-                    .equals(currentLang)) {
+                                                               .equals(currentLang)) {
                 return api;
             }
         }
@@ -307,8 +317,9 @@ public class OpacClient extends Application {
     }
 
     public Library getLibrary() {
-        if (getAccount() == null)
+        if (getAccount() == null) {
             return null;
+        }
         if (account != null && library != null) {
             if (sp.getLong(PREF_SELECTED_ACCOUNT, 0) == account.getId()) {
                 return library;

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/barcode/BarcodeScanIntegrator.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/barcode/BarcodeScanIntegrator.java
@@ -136,7 +136,8 @@ public class BarcodeScanIntegrator {
                     @Override
                     public void onClick(DialogInterface dialogInterface, int i) {
                         Uri uri = Uri
-                                .parse("http://www.amazon.com/gp/mas/dl/android?p=com.google.zxing.client.android");
+                                .parse("http://www.amazon.com/gp/mas/dl/android?p=com.google" +
+                                        ".zxing.client.android");
                         Intent intent = new Intent(Intent.ACTION_VIEW, uri);
                         ctx.startActivity(intent);
                     }
@@ -223,8 +224,8 @@ public class BarcodeScanIntegrator {
         }
 
         /**
-         * @return name of format, like "QR_CODE", "UPC_A". See
-         * {@code BarcodeFormat} for more format names.
+         * @return name of format, like "QR_CODE", "UPC_A". See {@code BarcodeFormat} for more
+         * format names.
          */
         public String getFormatName() {
             return formatName;

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/AboutActivity.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/AboutActivity.java
@@ -38,8 +38,8 @@ public class AboutActivity extends ActionBarActivity {
         setSupportActionBar((Toolbar) findViewById(R.id.toolbar));
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         getSupportFragmentManager().beginTransaction()
-                .replace(R.id.content_frame, getNewAboutFragment())
-                .commit();
+                                   .replace(R.id.content_frame, getNewAboutFragment())
+                                   .commit();
     }
 
     protected PreferenceFragment getNewAboutFragment() {

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/AboutFragment.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/AboutFragment.java
@@ -48,10 +48,11 @@ public class AboutFragment extends PreferenceFragment {
                     @Override
                     public boolean onPreferenceClick(Preference preference) {
                         Intent i = new Intent(Intent.ACTION_VIEW);
-                        if (getString(R.string.website_url).contains("de"))
+                        if (getString(R.string.website_url).contains("de")) {
                             i.setData(Uri.parse("http://de.opacapp.net"));
-                        else
+                        } else {
                             i.setData(Uri.parse("http://en.opacapp.net"));
+                        }
                         startActivity(i);
                         return false;
                     }

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/AccountEditActivity.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/AccountEditActivity.java
@@ -216,38 +216,40 @@ public class AccountEditActivity extends ActionBarActivity {
             return true;
         } else if (item.getItemId() == R.id.action_cancel) {
             if (getIntent().hasExtra("adding")
-                    && getIntent().getBooleanExtra("adding", false))
+                    && getIntent().getBooleanExtra("adding", false)) {
                 delete();
+            }
             supportFinishAfterTransition();
             return true;
         } else if (item.getItemId() == R.id.action_delete) {
             AlertDialog.Builder builder = new AlertDialog.Builder(this);
             builder.setMessage(R.string.account_delete_confirm)
-                    .setCancelable(true)
-                    .setNegativeButton(R.string.no,
-                            new DialogInterface.OnClickListener() {
-                                @Override
-                                public void onClick(DialogInterface d, int id) {
-                                    d.cancel();
-                                }
-                            })
-                    .setPositiveButton(R.string.delete,
-                            new DialogInterface.OnClickListener() {
-                                @Override
-                                public void onClick(DialogInterface d, int id) {
-                                    d.dismiss();
-                                    delete();
-                                    finish();
-                                }
-                            })
-                    .setOnCancelListener(
-                            new DialogInterface.OnCancelListener() {
-                                @Override
-                                public void onCancel(DialogInterface d) {
-                                    if (d != null)
-                                        d.cancel();
-                                }
-                            });
+                   .setCancelable(true)
+                   .setNegativeButton(R.string.no,
+                           new DialogInterface.OnClickListener() {
+                               @Override
+                               public void onClick(DialogInterface d, int id) {
+                                   d.cancel();
+                               }
+                           })
+                   .setPositiveButton(R.string.delete,
+                           new DialogInterface.OnClickListener() {
+                               @Override
+                               public void onClick(DialogInterface d, int id) {
+                                   d.dismiss();
+                                   delete();
+                                   finish();
+                               }
+                           })
+                   .setOnCancelListener(
+                           new DialogInterface.OnCancelListener() {
+                               @Override
+                               public void onCancel(DialogInterface d) {
+                                   if (d != null) {
+                                       d.cancel();
+                                   }
+                               }
+                           });
             AlertDialog alert = builder.create();
             alert.show();
             return true;
@@ -349,42 +351,42 @@ public class AccountEditActivity extends ActionBarActivity {
                                 getResources().getString(
                                         R.string.user_data_opac_message),
                                 e.getMessage()))
-                        .setPositiveButton(R.string.yes,
-                                new DialogInterface.OnClickListener() {
-                                    @Override
-                                    public void onClick(DialogInterface dialog,
-                                                        int which) {
-                                        save();
-                                        close();
-                                    }
-                                })
-                        .setNegativeButton(R.string.no,
-                                new DialogInterface.OnClickListener() {
-                                    @Override
-                                    public void onClick(DialogInterface dialog,
-                                                        int which) {
-                                    }
-                                }).create().show();
+                       .setPositiveButton(R.string.yes,
+                               new DialogInterface.OnClickListener() {
+                                   @Override
+                                   public void onClick(DialogInterface dialog,
+                                                       int which) {
+                                       save();
+                                       close();
+                                   }
+                               })
+                       .setNegativeButton(R.string.no,
+                               new DialogInterface.OnClickListener() {
+                                   @Override
+                                   public void onClick(DialogInterface dialog,
+                                                       int which) {
+                                   }
+                               }).create().show();
             } else {
                 AlertDialog.Builder builder = new AlertDialog.Builder(
                         AccountEditActivity.this);
                 builder.setMessage(R.string.user_data_connection_error)
-                        .setPositiveButton(R.string.yes,
-                                new DialogInterface.OnClickListener() {
-                                    @Override
-                                    public void onClick(DialogInterface dialog,
-                                                        int which) {
-                                        save();
-                                        close();
-                                    }
-                                })
-                        .setNegativeButton(R.string.no,
-                                new DialogInterface.OnClickListener() {
-                                    @Override
-                                    public void onClick(DialogInterface dialog,
-                                                        int which) {
-                                    }
-                                }).create().show();
+                       .setPositiveButton(R.string.yes,
+                               new DialogInterface.OnClickListener() {
+                                   @Override
+                                   public void onClick(DialogInterface dialog,
+                                                       int which) {
+                                       save();
+                                       close();
+                                   }
+                               })
+                       .setNegativeButton(R.string.no,
+                               new DialogInterface.OnClickListener() {
+                                   @Override
+                                   public void onClick(DialogInterface dialog,
+                                                       int which) {
+                                   }
+                               }).create().show();
             }
         }
     }

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/AccountFragment.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/AccountFragment.java
@@ -138,11 +138,11 @@ public class AccountFragment extends Fragment implements
 
         if (getActivity().getIntent().getExtras() != null) {
             if (getActivity().getIntent().getExtras()
-                    .containsKey("notifications")) {
+                             .containsKey("notifications")) {
                 AccountDataSource adata = new AccountDataSource(getActivity());
                 adata.open();
                 Bundle notif = getActivity().getIntent().getExtras()
-                        .getBundle("notifications");
+                                            .getBundle("notifications");
                 Set<String> keys = notif.keySet();
                 for (String key : keys) {
                     long[] val = notif.getLongArray(key);
@@ -153,11 +153,12 @@ public class AccountFragment extends Fragment implements
                 if (getActivity().getIntent().getExtras().getLong("account") != app
                         .getAccount().getId()) {
                     app.setAccount(getActivity().getIntent().getExtras()
-                            .getLong("account"));
+                                                .getLong("account"));
                     ((OpacActivity) getActivity()).accountSelected(app
                             .getAccount());
                 }
-                NotificationManager nMgr = (NotificationManager) getActivity().getSystemService(Context.NOTIFICATION_SERVICE);
+                NotificationManager nMgr = (NotificationManager) getActivity()
+                        .getSystemService(Context.NOTIFICATION_SERVICE);
                 nMgr.cancel(OpacClient.NOTIF_ID);
             }
         }
@@ -255,7 +256,7 @@ public class AccountFragment extends Fragment implements
                                             android.content.Intent.EXTRA_SUBJECT,
                                             "Bibliothek "
                                                     + app.getLibrary()
-                                                    .getIdent());
+                                                         .getIdent());
                             emailIntent.putExtra(
                                     android.content.Intent.EXTRA_TEXT,
                                     getResources().getString(
@@ -368,82 +369,84 @@ public class AccountFragment extends Fragment implements
         }
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
         builder.setMessage(R.string.cancel_confirm)
-                .setCancelable(true)
-                .setNegativeButton(R.string.no,
-                        new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface d, int id) {
-                                d.cancel();
-                            }
-                        })
-                .setPositiveButton(R.string.yes,
-                        new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface d, int id) {
-                                d.dismiss();
+               .setCancelable(true)
+               .setNegativeButton(R.string.no,
+                       new DialogInterface.OnClickListener() {
+                           @Override
+                           public void onClick(DialogInterface d, int id) {
+                               d.cancel();
+                           }
+                       })
+               .setPositiveButton(R.string.yes,
+                       new DialogInterface.OnClickListener() {
+                           @Override
+                           public void onClick(DialogInterface d, int id) {
+                               d.dismiss();
 
-                                MultiStepResultHelper msrhCancel = new MultiStepResultHelper(
-                                        getActivity(), a,
-                                        R.string.doing_cancel);
-                                msrhCancel.setCallback(new Callback() {
-                                    @Override
-                                    public void onSuccess(MultiStepResult result) {
-                                        invalidateData();
-                                    }
+                               MultiStepResultHelper msrhCancel = new MultiStepResultHelper(
+                                       getActivity(), a,
+                                       R.string.doing_cancel);
+                               msrhCancel.setCallback(new Callback() {
+                                   @Override
+                                   public void onSuccess(MultiStepResult result) {
+                                       invalidateData();
+                                   }
 
-                                    @Override
-                                    public void onError(MultiStepResult result) {
-                                        AlertDialog.Builder builder = new AlertDialog.Builder(
-                                                getActivity());
-                                        builder.setMessage(result.getMessage())
-                                                .setCancelable(true)
-                                                .setNegativeButton(
-                                                        R.string.close,
-                                                        new DialogInterface.OnClickListener() {
-                                                            @Override
-                                                            public void onClick(
-                                                                    DialogInterface d,
-                                                                    int id) {
-                                                                d.cancel();
-                                                            }
-                                                        })
-                                                .setOnCancelListener(
-                                                        new DialogInterface.OnCancelListener() {
-                                                            @Override
-                                                            public void onCancel(
-                                                                    DialogInterface d) {
-                                                                if (d != null)
-                                                                    d.cancel();
-                                                            }
-                                                        });
-                                        AlertDialog alert = builder.create();
-                                        alert.show();
-                                    }
+                                   @Override
+                                   public void onError(MultiStepResult result) {
+                                       AlertDialog.Builder builder = new AlertDialog.Builder(
+                                               getActivity());
+                                       builder.setMessage(result.getMessage())
+                                              .setCancelable(true)
+                                              .setNegativeButton(
+                                                      R.string.close,
+                                                      new DialogInterface.OnClickListener() {
+                                                          @Override
+                                                          public void onClick(
+                                                                  DialogInterface d,
+                                                                  int id) {
+                                                              d.cancel();
+                                                          }
+                                                      })
+                                              .setOnCancelListener(
+                                                      new DialogInterface.OnCancelListener() {
+                                                          @Override
+                                                          public void onCancel(
+                                                                  DialogInterface d) {
+                                                              if (d != null) {
+                                                                  d.cancel();
+                                                              }
+                                                          }
+                                                      });
+                                       AlertDialog alert = builder.create();
+                                       alert.show();
+                                   }
 
-                                    @Override
-                                    public void onUnhandledResult(
-                                            MultiStepResult result) {
-                                    }
+                                   @Override
+                                   public void onUnhandledResult(
+                                           MultiStepResult result) {
+                                   }
 
-                                    @Override
-                                    public void onUserCancel() {
-                                    }
+                                   @Override
+                                   public void onUserCancel() {
+                                   }
 
-                                    @Override
-                                    public StepTask<?> newTask() {
-                                        return new CancelTask();
-                                    }
-                                });
-                                msrhCancel.start();
-                            }
-                        })
-                .setOnCancelListener(new DialogInterface.OnCancelListener() {
-                    @Override
-                    public void onCancel(DialogInterface d) {
-                        if (d != null)
-                            d.cancel();
-                    }
-                });
+                                   @Override
+                                   public StepTask<?> newTask() {
+                                       return new CancelTask();
+                                   }
+                               });
+                               msrhCancel.start();
+                           }
+                       })
+               .setOnCancelListener(new DialogInterface.OnCancelListener() {
+                   @Override
+                   public void onCancel(DialogInterface d) {
+                       if (d != null) {
+                           d.cancel();
+                       }
+                   }
+               });
         AlertDialog alert = builder.create();
         alert.show();
     }
@@ -464,23 +467,24 @@ public class AccountFragment extends Fragment implements
         msrhProlong.setCallback(new Callback() {
             @Override
             public void onSuccess(MultiStepResult result) {
-                if (getActivity() == null)
+                if (getActivity() == null) {
                     return;
+                }
                 invalidateData();
 
                 if (result.getMessage() != null) {
                     AlertDialog.Builder builder = new AlertDialog.Builder(
                             getActivity());
                     builder.setMessage(result.getMessage())
-                            .setCancelable(false)
-                            .setNegativeButton(R.string.close,
-                                    new DialogInterface.OnClickListener() {
-                                        @Override
-                                        public void onClick(
-                                                DialogInterface dialog, int id) {
-                                            dialog.cancel();
-                                        }
-                                    });
+                           .setCancelable(false)
+                           .setNegativeButton(R.string.close,
+                                   new DialogInterface.OnClickListener() {
+                                       @Override
+                                       public void onClick(
+                                               DialogInterface dialog, int id) {
+                                           dialog.cancel();
+                                       }
+                                   });
                     AlertDialog alert = builder.create();
                     alert.show();
                 }
@@ -488,28 +492,30 @@ public class AccountFragment extends Fragment implements
 
             @Override
             public void onError(MultiStepResult result) {
-                if (getActivity() == null)
+                if (getActivity() == null) {
                     return;
+                }
                 AlertDialog.Builder builder = new AlertDialog.Builder(
                         getActivity());
                 builder.setMessage(result.getMessage())
-                        .setCancelable(true)
-                        .setNegativeButton(R.string.close,
-                                new DialogInterface.OnClickListener() {
-                                    @Override
-                                    public void onClick(DialogInterface d,
-                                                        int id) {
-                                        d.cancel();
-                                    }
-                                })
-                        .setOnCancelListener(
-                                new DialogInterface.OnCancelListener() {
-                                    @Override
-                                    public void onCancel(DialogInterface d) {
-                                        if (d != null)
-                                            d.cancel();
-                                    }
-                                });
+                       .setCancelable(true)
+                       .setNegativeButton(R.string.close,
+                               new DialogInterface.OnClickListener() {
+                                   @Override
+                                   public void onClick(DialogInterface d,
+                                                       int id) {
+                                       d.cancel();
+                                   }
+                               })
+                       .setOnCancelListener(
+                               new DialogInterface.OnCancelListener() {
+                                   @Override
+                                   public void onCancel(DialogInterface d) {
+                                       if (d != null) {
+                                           d.cancel();
+                                       }
+                                   }
+                               });
                 AlertDialog alert = builder.create();
                 alert.show();
             }
@@ -555,10 +561,12 @@ public class AccountFragment extends Fragment implements
     }
 
     public void show_connectivity_error(Exception e) {
-        if (e != null)
+        if (e != null) {
             e.printStackTrace();
-        if (getActivity() == null)
+        }
+        if (getActivity() == null) {
             return;
+        }
         if (e instanceof OpacErrorException) {
             AccountDataSource adatasource = new AccountDataSource(getActivity());
             adatasource.open();
@@ -573,12 +581,13 @@ public class AccountFragment extends Fragment implements
         View connError = getActivity().getLayoutInflater().inflate(
                 R.layout.error_connectivity, errorView);
 
-        if (e != null && e instanceof SSLSecurityException)
+        if (e != null && e instanceof SSLSecurityException) {
             ((TextView) connError.findViewById(R.id.tvErrBody))
                     .setText(R.string.connection_error_detail_security);
-        else if (e != null && e instanceof NotReachableException)
+        } else if (e != null && e instanceof NotReachableException) {
             ((TextView) connError.findViewById(R.id.tvErrBody))
                     .setText(R.string.connection_error_detail_nre);
+        }
         ((Button) connError.findViewById(R.id.btRetry))
                 .setOnClickListener(new OnClickListener() {
                     @Override
@@ -613,8 +622,9 @@ public class AccountFragment extends Fragment implements
         if (getActivity() == null && OpacClient.getEmergencyContext() != null) {
             adatasource = new AccountDataSource(
                     OpacClient.getEmergencyContext());
-        } else
+        } else {
             adatasource = new AccountDataSource(getActivity());
+        }
 
         adatasource.open();
         adatasource.storeCachedAccountData(
@@ -635,8 +645,9 @@ public class AccountFragment extends Fragment implements
 
     @SuppressWarnings("deprecation")
     public void displaydata(AccountData result, boolean fromcache) {
-        if (getActivity() == null)
+        if (getActivity() == null) {
             return;
+        }
         view.findViewById(R.id.svAccount).setVisibility(View.VISIBLE);
         view.findViewById(R.id.llLoading).setVisibility(View.GONE);
         view.findViewById(R.id.unsupported_error).setVisibility(View.GONE);
@@ -710,7 +721,7 @@ public class AccountFragment extends Fragment implements
                         }
                     };
                     v.findViewById(R.id.tvTitel)
-                            .setOnClickListener(gotoDetails);
+                     .setOnClickListener(gotoDetails);
                     v.findViewById(R.id.tvVerfasser).setOnClickListener(
                             gotoDetails);
                     v.findViewById(R.id.tvStatus).setOnClickListener(
@@ -898,7 +909,7 @@ public class AccountFragment extends Fragment implements
                         }
                     };
                     v.findViewById(R.id.tvTitel)
-                            .setOnClickListener(gotoDetails);
+                     .setOnClickListener(gotoDetails);
                     v.findViewById(R.id.tvVerfasser).setOnClickListener(
                             gotoDetails);
                     v.findViewById(R.id.tvStatus).setOnClickListener(
@@ -924,7 +935,7 @@ public class AccountFragment extends Fragment implements
                             .setVisibility(View.VISIBLE);
                 } else if (item.containsKey(AccountData.KEY_RESERVATION_EXPIRE)
                         && item.get(AccountData.KEY_RESERVATION_EXPIRE)
-                        .length() > 6) {
+                               .length() > 6) {
                     ((TextView) v.findViewById(R.id.tvStatus))
                             .setText(Html.fromHtml("bis "
                                     + item.get(AccountData.KEY_RESERVATION_EXPIRE)));
@@ -1009,8 +1020,9 @@ public class AccountFragment extends Fragment implements
 
     public void refreshage() {
         try {
-            if (view.findViewById(R.id.tvAge) == null)
+            if (view.findViewById(R.id.tvAge) == null) {
                 return;
+            }
 
             long age = System.currentTimeMillis() - refreshtime;
             if (age < 60 * 1000) {
@@ -1070,23 +1082,24 @@ public class AccountFragment extends Fragment implements
                 AlertDialog.Builder builder = new AlertDialog.Builder(
                         getActivity());
                 builder.setMessage(result.getMessage())
-                        .setCancelable(true)
-                        .setNegativeButton(R.string.close,
-                                new DialogInterface.OnClickListener() {
-                                    @Override
-                                    public void onClick(DialogInterface d,
-                                                        int id) {
-                                        d.cancel();
-                                    }
-                                })
-                        .setOnCancelListener(
-                                new DialogInterface.OnCancelListener() {
-                                    @Override
-                                    public void onCancel(DialogInterface d) {
-                                        if (d != null)
-                                            d.cancel();
-                                    }
-                                });
+                       .setCancelable(true)
+                       .setNegativeButton(R.string.close,
+                               new DialogInterface.OnClickListener() {
+                                   @Override
+                                   public void onClick(DialogInterface d,
+                                                       int id) {
+                                       d.cancel();
+                                   }
+                               })
+                       .setOnCancelListener(
+                               new DialogInterface.OnCancelListener() {
+                                   @Override
+                                   public void onCancel(DialogInterface d) {
+                                       if (d != null) {
+                                           d.cancel();
+                                       }
+                                   }
+                               });
                 AlertDialog alert = builder.create();
                 alert.show();
             }
@@ -1119,21 +1132,21 @@ public class AccountFragment extends Fragment implements
 
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
         builder.setMessage(R.string.prolong_all_confirm)
-                .setCancelable(true)
-                .setNegativeButton(R.string.no,
-                        new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface d, int id) {
-                                d.cancel();
-                            }
-                        })
-                .setPositiveButton(R.string.yes,
-                        new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface d, int id) {
-                                prolongAllDo();
-                            }
-                        });
+               .setCancelable(true)
+               .setNegativeButton(R.string.no,
+                       new DialogInterface.OnClickListener() {
+                           @Override
+                           public void onClick(DialogInterface d, int id) {
+                               d.cancel();
+                           }
+                       })
+               .setPositiveButton(R.string.yes,
+                       new DialogInterface.OnClickListener() {
+                           @Override
+                           public void onClick(DialogInterface d, int id) {
+                               prolongAllDo();
+                           }
+                       });
         AlertDialog alert = builder.create();
         alert.show();
 
@@ -1146,8 +1159,9 @@ public class AccountFragment extends Fragment implements
         msrhProlong.setCallback(new Callback() {
             @Override
             public void onSuccess(MultiStepResult result) {
-                if (getActivity() == null)
+                if (getActivity() == null) {
                     return;
+                }
                 ProlongAllResult res = (ProlongAllResult) result;
                 AlertDialog.Builder builder = new AlertDialog.Builder(
                         getActivity());
@@ -1178,28 +1192,30 @@ public class AccountFragment extends Fragment implements
 
             @Override
             public void onError(MultiStepResult result) {
-                if (getActivity() == null)
+                if (getActivity() == null) {
                     return;
+                }
                 AlertDialog.Builder builder = new AlertDialog.Builder(
                         getActivity());
                 builder.setMessage(result.getMessage())
-                        .setCancelable(true)
-                        .setNegativeButton(R.string.close,
-                                new DialogInterface.OnClickListener() {
-                                    @Override
-                                    public void onClick(DialogInterface d,
-                                                        int id) {
-                                        d.cancel();
-                                    }
-                                })
-                        .setOnCancelListener(
-                                new DialogInterface.OnCancelListener() {
-                                    @Override
-                                    public void onCancel(DialogInterface d) {
-                                        if (d != null)
-                                            d.cancel();
-                                    }
-                                });
+                       .setCancelable(true)
+                       .setNegativeButton(R.string.close,
+                               new DialogInterface.OnClickListener() {
+                                   @Override
+                                   public void onClick(DialogInterface d,
+                                                       int id) {
+                                       d.cancel();
+                                   }
+                               })
+                       .setOnCancelListener(
+                               new DialogInterface.OnCancelListener() {
+                                   @Override
+                                   public void onCancel(DialogInterface d) {
+                                       if (d != null) {
+                                           d.cancel();
+                                       }
+                                   }
+                               });
                 AlertDialog alert = builder.create();
                 alert.show();
             }
@@ -1263,9 +1279,9 @@ public class AccountFragment extends Fragment implements
                 nameValuePairs
                         .add(new BasicNameValuePair("version",
                                 getActivity().getPackageManager()
-                                        .getPackageInfo(
-                                                getActivity().getPackageName(),
-                                                0).versionName));
+                                             .getPackageInfo(
+                                                     getActivity().getPackageName(),
+                                                     0).versionName));
             } catch (Exception e) {
                 e.printStackTrace();
             }
@@ -1278,11 +1294,12 @@ public class AccountFragment extends Fragment implements
                     android.os.Build.MANUFACTURER + " "
                             + android.os.Build.MODEL));
             nameValuePairs.add(new BasicNameValuePair("bib", app.getLibrary()
-                    .getIdent()));
+                                                                .getIdent()));
 
             try {
                 nameValuePairs.add(new BasicNameValuePair("html", app.getApi()
-                        .getAccountExtendableInfo(app.getAccount())));
+                                                                     .getAccountExtendableInfo(
+                                                                             app.getAccount())));
             } catch (Exception e1) {
                 e1.printStackTrace();
                 return 1;
@@ -1306,8 +1323,9 @@ public class AccountFragment extends Fragment implements
 
         @Override
         protected void onPostExecute(Integer result) {
-            if (getActivity() == null)
+            if (getActivity() == null) {
                 return;
+            }
 
             dialog.dismiss();
             Button btSend = (Button) view.findViewById(R.id.btSend);
@@ -1388,22 +1406,23 @@ public class AccountFragment extends Fragment implements
 
         @Override
         protected void onPostExecute(CancelResult result) {
-            if (getActivity() == null)
+            if (getActivity() == null) {
                 return;
+            }
 
             if (result == null) {
                 AlertDialog.Builder builder = new AlertDialog.Builder(
                         getActivity());
                 builder.setMessage(R.string.error)
-                        .setCancelable(true)
-                        .setNegativeButton(R.string.close,
-                                new DialogInterface.OnClickListener() {
-                                    @Override
-                                    public void onClick(DialogInterface dialog,
-                                                        int id) {
-                                        dialog.cancel();
-                                    }
-                                });
+                       .setCancelable(true)
+                       .setNegativeButton(R.string.close,
+                               new DialogInterface.OnClickListener() {
+                                   @Override
+                                   public void onClick(DialogInterface dialog,
+                                                       int id) {
+                                       dialog.cancel();
+                                   }
+                               });
                 AlertDialog alert = builder.create();
                 alert.show();
             }
@@ -1426,8 +1445,9 @@ public class AccountFragment extends Fragment implements
         @Override
         protected void onPostExecute(final String result) {
             dialog.dismiss();
-            if (getActivity() == null)
+            if (getActivity() == null) {
                 return;
+            }
             if (result.toString().contains("acsm")) {
                 String[] download_clients = new String[]{
                         "com.android.aldiko", "com.aldiko.android",
@@ -1451,42 +1471,44 @@ public class AccountFragment extends Fragment implements
                     AlertDialog.Builder builder = new AlertDialog.Builder(
                             getActivity());
                     builder.setMessage(R.string.reader_needed)
-                            .setCancelable(true)
-                            .setNegativeButton(R.string.cancel,
-                                    new DialogInterface.OnClickListener() {
-                                        @Override
-                                        public void onClick(
-                                                DialogInterface dialog, int id) {
-                                            dialog.cancel();
-                                        }
-                                    })
-                            .setNeutralButton(R.string.reader_needed_ignore,
-                                    new DialogInterface.OnClickListener() {
-                                        @Override
-                                        public void onClick(
-                                                DialogInterface dialog, int id) {
-                                            Intent i = new Intent(
-                                                    Intent.ACTION_VIEW);
-                                            i.setData(Uri.parse(result));
-                                            sp.edit()
-                                                    .putBoolean(
-                                                            "reader_needed_ignore",
-                                                            true).commit();
-                                            startActivity(i);
-                                        }
-                                    })
-                            .setPositiveButton(R.string.download,
-                                    new DialogInterface.OnClickListener() {
-                                        @Override
-                                        public void onClick(
-                                                DialogInterface dialog, int id) {
-                                            dialog.cancel();
-                                            Intent i = new Intent(
-                                                    Intent.ACTION_VIEW,
-                                                    Uri.parse("market://details?id=de.bluefirereader"));
-                                            startActivity(i);
-                                        }
-                                    });
+                           .setCancelable(true)
+                           .setNegativeButton(R.string.cancel,
+                                   new DialogInterface.OnClickListener() {
+                                       @Override
+                                       public void onClick(
+                                               DialogInterface dialog, int id) {
+                                           dialog.cancel();
+                                       }
+                                   })
+                           .setNeutralButton(R.string.reader_needed_ignore,
+                                   new DialogInterface.OnClickListener() {
+                                       @Override
+                                       public void onClick(
+                                               DialogInterface dialog, int id) {
+                                           Intent i = new Intent(
+                                                   Intent.ACTION_VIEW);
+                                           i.setData(Uri.parse(result));
+                                           sp.edit()
+                                             .putBoolean(
+                                                     "reader_needed_ignore",
+                                                     true).commit();
+                                           startActivity(i);
+                                       }
+                                   })
+                           .setPositiveButton(R.string.download,
+                                   new DialogInterface.OnClickListener() {
+                                       @Override
+                                       public void onClick(
+                                               DialogInterface dialog, int id) {
+                                           dialog.cancel();
+                                           Intent i = new Intent(
+                                                   Intent.ACTION_VIEW,
+                                                   Uri.parse(
+                                                           "market://details?id=de" +
+                                                                   ".bluefirereader"));
+                                           startActivity(i);
+                                       }
+                                   });
                     AlertDialog alert = builder.create();
                     alert.show();
                     return;
@@ -1533,22 +1555,23 @@ public class AccountFragment extends Fragment implements
 
         @Override
         protected void onPostExecute(ProlongResult res) {
-            if (getActivity() == null)
+            if (getActivity() == null) {
                 return;
+            }
 
             if (!success || res == null) {
                 AlertDialog.Builder builder = new AlertDialog.Builder(
                         getActivity());
                 builder.setMessage(R.string.error)
-                        .setCancelable(true)
-                        .setNegativeButton(R.string.close,
-                                new DialogInterface.OnClickListener() {
-                                    @Override
-                                    public void onClick(DialogInterface dialog,
-                                                        int id) {
-                                        dialog.cancel();
-                                    }
-                                });
+                       .setCancelable(true)
+                       .setNegativeButton(R.string.close,
+                               new DialogInterface.OnClickListener() {
+                                   @Override
+                                   public void onClick(DialogInterface dialog,
+                                                       int id) {
+                                       dialog.cancel();
+                                   }
+                               });
                 AlertDialog alert = builder.create();
                 alert.show();
                 return;
@@ -1583,22 +1606,23 @@ public class AccountFragment extends Fragment implements
 
         @Override
         protected void onPostExecute(ProlongAllResult result) {
-            if (getActivity() == null)
+            if (getActivity() == null) {
                 return;
+            }
 
             if (result == null) {
                 AlertDialog.Builder builder = new AlertDialog.Builder(
                         getActivity());
                 builder.setMessage(R.string.error)
-                        .setCancelable(true)
-                        .setNegativeButton(R.string.close,
-                                new DialogInterface.OnClickListener() {
-                                    @Override
-                                    public void onClick(DialogInterface dialog,
-                                                        int id) {
-                                        dialog.cancel();
-                                    }
-                                });
+                       .setCancelable(true)
+                       .setNegativeButton(R.string.close,
+                               new DialogInterface.OnClickListener() {
+                                   @Override
+                                   public void onClick(DialogInterface dialog,
+                                                       int id) {
+                                       dialog.cancel();
+                                   }
+                               });
                 AlertDialog alert = builder.create();
                 alert.show();
             }
@@ -1687,22 +1711,23 @@ public class AccountFragment extends Fragment implements
 
         @Override
         protected void onPostExecute(BookingResult res) {
-            if (getActivity() == null)
+            if (getActivity() == null) {
                 return;
+            }
 
             if (res == null) {
                 AlertDialog.Builder builder = new AlertDialog.Builder(
                         getActivity());
                 builder.setMessage(R.string.error)
-                        .setCancelable(true)
-                        .setNegativeButton(R.string.close,
-                                new DialogInterface.OnClickListener() {
-                                    @Override
-                                    public void onClick(DialogInterface dialog,
-                                                        int id) {
-                                        dialog.cancel();
-                                    }
-                                });
+                       .setCancelable(true)
+                       .setNegativeButton(R.string.close,
+                               new DialogInterface.OnClickListener() {
+                                   @Override
+                                   public void onClick(DialogInterface dialog,
+                                                       int id) {
+                                       dialog.cancel();
+                                   }
+                               });
                 AlertDialog alert = builder.create();
                 alert.show();
                 return;

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/AccountListActivity.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/AccountListActivity.java
@@ -128,8 +128,9 @@ public class AccountListActivity extends ActionBarActivity {
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (requestCode == ACCOUNT_EDIT_REQUEST_CODE)
+        if (requestCode == ACCOUNT_EDIT_REQUEST_CODE) {
             refreshLv();
+        }
     }
 
 }

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/AccountListAdapter.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/AccountListAdapter.java
@@ -81,7 +81,8 @@ public class AccountListAdapter extends ArrayAdapter<Account> {
         }
 
         if (((OpacClient) ((Activity) context).getApplication()).getAccount()
-                .getId() == item.getId() && highlight) {
+                                                                .getId() == item.getId() &&
+                highlight) {
             view.findViewById(R.id.rlItem).setBackgroundColor(
                     context.getResources().getColor(R.color.accent_red));
         } else {
@@ -105,11 +106,13 @@ public class AccountListAdapter extends ArrayAdapter<Account> {
             e.printStackTrace();
         }
         TextView tvName = (TextView) view.findViewById(R.id.tvName);
-        if (item.getName() != null)
+        if (item.getName() != null) {
             tvName.setText(item.getName());
+        }
         TextView tvLabel = (TextView) view.findViewById(R.id.tvLabel);
-        if (item.getLabel() != null)
+        if (item.getLabel() != null) {
             tvLabel.setText(item.getLabel());
+        }
         return view;
     }
 }

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/InfoFragment.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/InfoFragment.java
@@ -59,7 +59,7 @@ public class InfoFragment extends Fragment implements AccountSelectedListener {
 
         try {
             String infoUrl = app.getLibrary().getData()
-                    .getString("information");
+                                .getString("information");
             if (infoUrl == null || infoUrl.equals("null")) {
                 wvInfo.setVisibility(View.GONE);
                 tvErr.setVisibility(View.VISIBLE);
@@ -121,11 +121,12 @@ public class InfoFragment extends Fragment implements AccountSelectedListener {
             @Override
             public boolean shouldOverrideUrlLoading(WebView view, String url) {
                 if (url.contains(app.getLibrary().getData()
-                        .optString("webviewcontain", "NOPE"))) {
+                                    .optString("webviewcontain", "NOPE"))) {
                     return false;
                 }
-                if (getActivity() == null)
+                if (getActivity() == null) {
                     return false;
+                }
                 Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
                 startActivity(intent);
                 return true;

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/LibraryListActivity.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/LibraryListActivity.java
@@ -105,12 +105,15 @@ public class LibraryListActivity extends ActionBarActivity {
         final ImageView ivLocationIcon = (ImageView) findViewById(R.id.ivLocationIcon);
         final LinearLayout llLocate = (LinearLayout) findViewById(R.id.llLocate);
 
-        final LocationManager locationManager = (LocationManager) getSystemService(Context.LOCATION_SERVICE);
+        final LocationManager locationManager =
+                (LocationManager) getSystemService(Context.LOCATION_SERVICE);
         Criteria criteria = new Criteria();
         criteria.setAccuracy(Criteria.ACCURACY_COARSE); // no GPS
         final String provider = locationManager.getBestProvider(criteria, true);
         if (provider == null) // no geolocation available
+        {
             llLocate.setVisibility(View.GONE);
+        }
 
         llLocate.setOnClickListener(new OnClickListener() {
 
@@ -129,15 +132,17 @@ public class LibraryListActivity extends ActionBarActivity {
             }
         });
 
-        final RelativeLayout rlSuggestLibrary = (RelativeLayout) findViewById(R.id.rlSuggestLibrary);
+        final RelativeLayout rlSuggestLibrary =
+                (RelativeLayout) findViewById(R.id.rlSuggestLibrary);
         rlSuggestLibrary.setOnClickListener(new OnClickListener() {
 
             @Override
             public void onClick(View v) {
                 Intent intent = new Intent(LibraryListActivity.this,
                         SuggestLibraryActivity.class);
-                if (getIntent().hasExtra("welcome"))
+                if (getIntent().hasExtra("welcome")) {
                     intent.putExtra("welcome", true);
+                }
                 ActivityOptionsCompat options = ActivityOptionsCompat.makeScaleUpAnimation
                         (rlSuggestLibrary, rlSuggestLibrary.getLeft(), rlSuggestLibrary.getTop(),
                                 rlSuggestLibrary.getWidth(), rlSuggestLibrary.getHeight());
@@ -189,13 +194,15 @@ public class LibraryListActivity extends ActionBarActivity {
         final TextView tvLocateString = (TextView) findViewById(R.id.tvLocateString);
         final ImageView ivLocationIcon = (ImageView) findViewById(R.id.ivLocationIcon);
 
-        final LocationManager locationManager = (LocationManager) getSystemService(Context.LOCATION_SERVICE);
+        final LocationManager locationManager =
+                (LocationManager) getSystemService(Context.LOCATION_SERVICE);
         Criteria criteria = new Criteria();
         criteria.setAccuracy(Criteria.ACCURACY_COARSE); // no GPS
         final String provider = locationManager.getBestProvider(criteria, true);
 
-        if (provider == null)
+        if (provider == null) {
             return;
+        }
         locationManager.requestLocationUpdates(provider, 0, 0,
                 new LocationListener() {
                     @Override
@@ -213,8 +220,9 @@ public class LibraryListActivity extends ActionBarActivity {
 
                     @Override
                     public void onLocationChanged(Location location) {
-                        if (!visible)
+                        if (!visible) {
                             return;
+                        }
                         fragment = new LocatedLibraryListFragment();
                         Bundle args = new Bundle();
                         args.putInt("level", LEVEL_LIBRARY);
@@ -228,8 +236,9 @@ public class LibraryListActivity extends ActionBarActivity {
                             for (Library lib : libraries) {
                                 float[] result = new float[1];
                                 double[] geo = lib.getGeo();
-                                if (geo == null)
+                                if (geo == null) {
                                     continue;
+                                }
                                 Location.distanceBetween(lat, lon, geo[0],
                                         geo[1], result);
                                 lib.setGeo_distance(result[0]);
@@ -250,15 +259,18 @@ public class LibraryListActivity extends ActionBarActivity {
                                     .setTransition(
                                             FragmentTransaction.TRANSIT_FRAGMENT_FADE)
                                     .replace(R.id.container, fragment).commit();
-                            if (fragment2 != null)
+                            if (fragment2 != null) {
                                 getSupportFragmentManager().beginTransaction()
-                                        .detach(fragment2).commit();
-                            if (fragment3 != null)
+                                                           .detach(fragment2).commit();
+                            }
+                            if (fragment3 != null) {
                                 getSupportFragmentManager().beginTransaction()
-                                        .detach(fragment3).commit();
-                            if (fragment4 != null)
+                                                           .detach(fragment3).commit();
+                            }
+                            if (fragment4 != null) {
                                 getSupportFragmentManager().beginTransaction()
-                                        .detach(fragment4).commit();
+                                                           .detach(fragment4).commit();
+                            }
 
                             tvLocateString.setText(R.string.alphabetic_list);
                             ivLocationIcon.setImageResource(R.drawable.ic_list);
@@ -288,26 +300,30 @@ public class LibraryListActivity extends ActionBarActivity {
         fragment.setListAdapter(adapter);
         if (findViewById(R.id.llFragments) != null) {
             getSupportFragmentManager().beginTransaction()
-                    .replace(R.id.container, fragment).commit();
-            if (fragment2 != null)
+                                       .replace(R.id.container, fragment).commit();
+            if (fragment2 != null) {
                 getSupportFragmentManager().beginTransaction()
-                        .detach(fragment2).commit();
-            if (fragment3 != null)
+                                           .detach(fragment2).commit();
+            }
+            if (fragment3 != null) {
                 getSupportFragmentManager().beginTransaction()
-                        .detach(fragment3).commit();
-            if (fragment4 != null)
+                                           .detach(fragment3).commit();
+            }
+            if (fragment4 != null) {
                 getSupportFragmentManager().beginTransaction()
-                        .detach(fragment4).commit();
+                                           .detach(fragment4).commit();
+            }
         } else {
-            if (fade)
+            if (fade) {
                 getSupportFragmentManager()
                         .beginTransaction()
                         .setTransition(
                                 FragmentTransaction.TRANSIT_FRAGMENT_FADE)
                         .replace(R.id.container, fragment).commit();
-            else
+            } else {
                 getSupportFragmentManager().beginTransaction()
-                        .replace(R.id.container, fragment).commit();
+                                           .replace(R.id.container, fragment).commit();
+            }
         }
     }
 
@@ -337,19 +353,21 @@ public class LibraryListActivity extends ActionBarActivity {
         if (findViewById(R.id.llFragments) != null) {
             fragment2 = fragment;
             getSupportFragmentManager().beginTransaction()
-                    .replace(R.id.container2, fragment2).commit();
-            if (fragment3 != null)
+                                       .replace(R.id.container2, fragment2).commit();
+            if (fragment3 != null) {
                 getSupportFragmentManager().beginTransaction()
-                        .detach(fragment3).commit();
-            if (fragment4 != null)
+                                           .detach(fragment3).commit();
+            }
+            if (fragment4 != null) {
                 getSupportFragmentManager().beginTransaction()
-                        .detach(fragment4).commit();
+                                           .detach(fragment4).commit();
+            }
         } else if (data.size() > 1) {
             this.fragment = fragment;
             getSupportFragmentManager().beginTransaction()
-                    .replace(R.id.container, fragment).addToBackStack(null)
-                    .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN)
-                    .commit();
+                                       .replace(R.id.container, fragment).addToBackStack(null)
+                                       .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN)
+                                       .commit();
         }
     }
 
@@ -381,16 +399,17 @@ public class LibraryListActivity extends ActionBarActivity {
         if (findViewById(R.id.llFragments) != null) {
             fragment3 = fragment;
             getSupportFragmentManager().beginTransaction()
-                    .replace(R.id.container3, fragment3).commit();
-            if (fragment4 != null)
+                                       .replace(R.id.container3, fragment3).commit();
+            if (fragment4 != null) {
                 getSupportFragmentManager().beginTransaction()
-                        .detach(fragment4).commit();
+                                           .detach(fragment4).commit();
+            }
         } else if (data.size() > 1 || !list.get(0).equals(state)) {
             this.fragment = fragment;
             getSupportFragmentManager().beginTransaction()
-                    .replace(R.id.container, fragment).addToBackStack(null)
-                    .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN)
-                    .commit();
+                                       .replace(R.id.container, fragment).addToBackStack(null)
+                                       .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN)
+                                       .commit();
         }
     }
 
@@ -418,13 +437,13 @@ public class LibraryListActivity extends ActionBarActivity {
         if (findViewById(R.id.llFragments) != null) {
             fragment4 = fragment;
             getSupportFragmentManager().beginTransaction()
-                    .replace(R.id.container4, fragment4).commit();
+                                       .replace(R.id.container4, fragment4).commit();
         } else {
             this.fragment = fragment;
             getSupportFragmentManager().beginTransaction()
-                    .replace(R.id.container, fragment).addToBackStack(null)
-                    .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN)
-                    .commit();
+                                       .replace(R.id.container, fragment).addToBackStack(null)
+                                       .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN)
+                                       .commit();
         }
     }
 
@@ -437,14 +456,18 @@ public class LibraryListActivity extends ActionBarActivity {
         query = query.toLowerCase(Locale.GERMAN);
         for (Library lib : libraries) {
             int rank = 0;
-            if (lib.getCity().toLowerCase(Locale.GERMAN).contains(query))
+            if (lib.getCity().toLowerCase(Locale.GERMAN).contains(query)) {
                 rank += 3;
-            if (lib.getTitle().toLowerCase(Locale.GERMAN).contains(query))
+            }
+            if (lib.getTitle().toLowerCase(Locale.GERMAN).contains(query)) {
                 rank += 3;
-            if (lib.getState().toLowerCase(Locale.GERMAN).contains(query))
+            }
+            if (lib.getState().toLowerCase(Locale.GERMAN).contains(query)) {
                 rank += 2;
-            if (lib.getCountry().toLowerCase(Locale.GERMAN).contains(query))
+            }
+            if (lib.getCountry().toLowerCase(Locale.GERMAN).contains(query)) {
                 rank += 1;
+            }
             if (rank > 0) {
                 data.add(new LibrarySearchResult(lib, rank));
             }
@@ -460,17 +483,20 @@ public class LibraryListActivity extends ActionBarActivity {
                 R.layout.listitem_library, R.id.tvTitle, libraries);
         fragment.setListAdapter(adapter);
         getSupportFragmentManager().beginTransaction().addToBackStack(null)
-                .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE)
-                .replace(R.id.container, fragment).commit();
-        if (fragment2 != null)
+                                   .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE)
+                                   .replace(R.id.container, fragment).commit();
+        if (fragment2 != null) {
             getSupportFragmentManager().beginTransaction().detach(fragment2)
-                    .commit();
-        if (fragment3 != null)
+                                       .commit();
+        }
+        if (fragment3 != null) {
             getSupportFragmentManager().beginTransaction().detach(fragment3)
-                    .commit();
-        if (fragment4 != null)
+                                       .commit();
+        }
+        if (fragment4 != null) {
             getSupportFragmentManager().beginTransaction().detach(fragment4)
-                    .commit();
+                                       .commit();
+        }
 
         TextView tvLocateString = (TextView) findViewById(R.id.tvLocateString);
         ImageView ivLocationIcon = (ImageView) findViewById(R.id.ivLocationIcon);
@@ -503,21 +529,23 @@ public class LibraryListActivity extends ActionBarActivity {
 
         @Override
         public boolean equals(Object obj) {
-            if (obj instanceof LibrarySearchResult)
+            if (obj instanceof LibrarySearchResult) {
                 return library.equals(((LibrarySearchResult) obj).getLibrary());
-            else
+            } else {
                 return false;
+            }
         }
 
         @Override
         public int compareTo(LibrarySearchResult another) {
-            if (another.rank == rank)
+            if (another.rank == rank) {
                 return library.getCity().compareTo(
                         another.getLibrary().getCity());
-            else if (another.rank < rank)
+            } else if (another.rank < rank) {
                 return -1;
-            else
+            } else {
                 return 1;
+            }
         }
 
     }
@@ -570,8 +598,9 @@ public class LibraryListActivity extends ActionBarActivity {
                     Intent i = new Intent(getActivity(), AccountEditActivity.class);
                     i.putExtra("id", insertedid);
                     i.putExtra("adding", true);
-                    if (getActivity().getIntent().hasExtra("welcome"))
+                    if (getActivity().getIntent().hasExtra("welcome")) {
                         i.putExtra("welcome", true);
+                    }
                     getActivity().startActivity(i);
                     getActivity().finish();
                     break;
@@ -586,12 +615,14 @@ public class LibraryListActivity extends ActionBarActivity {
             setRetainInstance(true);
             view = super.onCreateView(inflater, container, savedInstanceState);
             ListView lv = ((ListView) view.findViewById(android.R.id.list));
-            lv.setChoiceMode(((LibraryListActivity) getActivity()).isTablet() ? AbsListView.CHOICE_MODE_SINGLE
+            lv.setChoiceMode(((LibraryListActivity) getActivity()).isTablet() ?
+                    AbsListView.CHOICE_MODE_SINGLE
                     : AbsListView.CHOICE_MODE_NONE);
             if (level == LEVEL_CITY) {
                 lv.setFastScrollEnabled(true);
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
                     lv.setFastScrollAlwaysVisible(true);
+                }
             }
             lv.setSelector(R.drawable.ripple);
             return view;
@@ -629,10 +660,11 @@ public class LibraryListActivity extends ActionBarActivity {
             while (i < getCount() && !found) {
                 String city = getItem(i);
                 String letter = city.substring(0, 1).toUpperCase(Locale.GERMAN);
-                if (Arrays.asList(letters).indexOf(letter) >= sectionIndex)
+                if (Arrays.asList(letters).indexOf(letter) >= sectionIndex) {
                     found = true;
-                else
+                } else {
                     i++;
+                }
             }
             return i;
         }
@@ -736,11 +768,13 @@ public class LibraryListActivity extends ActionBarActivity {
         @Override
         protected void onPostExecute(List<Library> result) {
             libraries = result;
-            if (dialog != null)
+            if (dialog != null) {
                 dialog.dismiss();
+            }
 
-            if (libraries == null)
+            if (libraries == null) {
                 return;
+            }
 
             // Get the intent, verify the action and get the query
             Intent intent = getIntent();

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/MainActivity.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/MainActivity.java
@@ -38,16 +38,15 @@ public class MainActivity extends OpacActivity implements
     private long account;
 
     /**
-     * Reads the first four blocks of an ISO 15693 NFC tag as ASCII bytes into a
-     * string.
+     * Reads the first four blocks of an ISO 15693 NFC tag as ASCII bytes into a string.
      *
-     * @return String Tag memory as a string (bytes converted as ASCII) or
-     * <code>null</code>
+     * @return String Tag memory as a string (bytes converted as ASCII) or <code>null</code>
      */
     @SuppressLint("NewApi")
     public static String readPageToString(android.nfc.Tag tag) {
-        if (tag == null)
+        if (tag == null) {
             return null;
+        }
         byte[] id = tag.getId();
         android.nfc.tech.NfcV tech = android.nfc.tech.NfcV.get(tag);
         byte[] readCmd = new byte[3 + id.length];
@@ -65,11 +64,13 @@ public class MainActivity extends OpacActivity implements
                 data = tech.transceive(readCmd);
                 for (int j = 0; j < data.length; j++) {
                     if (data[j] > 32 && data[j] < 127) // We only want printable
-                        // characters, there
-                        // might be some
-                        // nullbytes in it
-                        // otherwise.
+                    // characters, there
+                    // might be some
+                    // nullbytes in it
+                    // otherwise.
+                    {
                         stringbuilder.append((char) data[j]);
+                    }
                 }
             }
             tech.close();
@@ -150,8 +151,10 @@ public class MainActivity extends OpacActivity implements
 //		try {
 //			List<SearchField> fields = app.getApi()
 //					.getSearchFields(new SQLMetaDataSource(app), app.getLibrary());
-//			if (fields.contains(OpacApi.KEY_SEARCH_QUERY_BARCODE)) //TODO: This won't work with the new implementation. But what is it for?
-//				nfc_capable = false;							   //  	   Shouldn't this be set to true if the library supports searching for barcodes?
+//			if (fields.contains(OpacApi.KEY_SEARCH_QUERY_BARCODE)) //TODO: This won't work with
+// the new implementation. But what is it for?
+//				nfc_capable = false;							   //  	   Shouldn't this be set
+// to true if the library supports searching for barcodes?
 //		} catch (OpacErrorException e) {
 //			e.printStackTrace();
 //		}
@@ -222,10 +225,12 @@ public class MainActivity extends OpacActivity implements
         BarcodeScanIntegrator.ScanResult scanResult = BarcodeScanIntegrator
                 .parseActivityResult(requestCode, resultCode, idata);
         if (resultCode != RESULT_CANCELED && scanResult != null) {
-            if (scanResult.getContents() == null)
+            if (scanResult.getContents() == null) {
                 return;
-            if (scanResult.getContents().length() < 3)
+            }
+            if (scanResult.getContents().length() < 3) {
                 return;
+            }
 
             // We won't try to determine which type of barcode was
             // scanned anymore because of the new SearchField
@@ -280,7 +285,7 @@ public class MainActivity extends OpacActivity implements
     public void onNewIntent(Intent intent) {
         // TODO: Rewrite this for the new SearchField implementation
         /*if (nfc_capable && sp.getBoolean("nfc_search", false)) {
-			android.nfc.Tag tag = intent
+            android.nfc.Tag tag = intent
 					.getParcelableExtra(android.nfc.NfcAdapter.EXTRA_TAG);
 			String scanResult = readPageToString(tag);
 			if (scanResult != null) {
@@ -312,7 +317,7 @@ public class MainActivity extends OpacActivity implements
             // Insert the fragment
             FragmentManager fragmentManager = getSupportFragmentManager();
             fragmentManager.beginTransaction()
-                    .replace(R.id.content_frame_right, rightFragment).commit();
+                           .replace(R.id.content_frame_right, rightFragment).commit();
         } else {
             Intent intent = new Intent(this, SearchResultDetailActivity.class);
             intent.putExtra(SearchResultDetailFragment.ARG_ITEM_ID, mNr);
@@ -322,9 +327,10 @@ public class MainActivity extends OpacActivity implements
 
     @Override
     public void removeFragment() {
-        if (rightFragment != null)
+        if (rightFragment != null) {
             getSupportFragmentManager().beginTransaction().remove(rightFragment)
-                    .commit();
+                                       .commit();
+        }
     }
 
     @Override

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/MainPreferenceActivity.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/MainPreferenceActivity.java
@@ -16,8 +16,8 @@ public class MainPreferenceActivity extends ActionBarActivity {
         setSupportActionBar((Toolbar) findViewById(R.id.toolbar));
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         getSupportFragmentManager().beginTransaction()
-                .replace(R.id.content_frame, getNewMainPreferenceFragment())
-                .commit();
+                                   .replace(R.id.content_frame, getNewMainPreferenceFragment())
+                                   .commit();
     }
 
     protected PreferenceFragment getNewMainPreferenceFragment() {

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/MainPreferenceFragment.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/MainPreferenceFragment.java
@@ -54,7 +54,7 @@ public class MainPreferenceFragment extends PreferenceFragment {
 
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.ICE_CREAM_SANDWICH
                 || !context.getPackageManager()
-                .hasSystemFeature("android.hardware.nfc")) {
+                           .hasSystemFeature("android.hardware.nfc")) {
             findPreference("nfc_search").setEnabled(false);
         }
 

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/MultiStepResultHelper.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/MultiStepResultHelper.java
@@ -83,19 +83,22 @@ public class MultiStepResultHelper {
                 doStep(result.getActionIdentifier(), sp.getString("email", ""));
                 break;
             case ERROR:
-                if (callback != null)
+                if (callback != null) {
                     callback.onError(result);
+                }
                 break;
             case OK:
-                if (callback != null)
+                if (callback != null) {
                     callback.onSuccess(result);
+                }
                 break;
             case UNSUPPORTED:
                 // TODO: Show dialog
                 break;
             default:
-                if (callback != null)
+                if (callback != null) {
                     callback.onUnhandledResult(result);
+                }
                 break;
         }
     }
@@ -146,24 +149,25 @@ public class MultiStepResultHelper {
         }
 
         builder.setTitle(R.string.confirm_title)
-                .setView(view)
-                .setPositiveButton(R.string.confirm,
-                        new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialog, int id) {
-                                doStep(MultiStepResult.ACTION_CONFIRMATION,
-                                        "confirmed");
-                            }
-                        })
-                .setNegativeButton(R.string.cancel,
-                        new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialog, int id) {
-                                adialog.cancel();
-                                if (callback != null)
-                                    callback.onUserCancel();
-                            }
-                        });
+               .setView(view)
+               .setPositiveButton(R.string.confirm,
+                       new DialogInterface.OnClickListener() {
+                           @Override
+                           public void onClick(DialogInterface dialog, int id) {
+                               doStep(MultiStepResult.ACTION_CONFIRMATION,
+                                       "confirmed");
+                           }
+                       })
+               .setNegativeButton(R.string.cancel,
+                       new DialogInterface.OnClickListener() {
+                           @Override
+                           public void onClick(DialogInterface dialog, int id) {
+                               adialog.cancel();
+                               if (callback != null) {
+                                   callback.onUserCancel();
+                               }
+                           }
+                       });
         adialog = builder.create();
         adialog.show();
     }
@@ -206,8 +210,9 @@ public class MultiStepResultHelper {
                     @Override
                     public void onClick(DialogInterface dialog, int id) {
                         adialog.cancel();
-                        if (callback != null)
+                        if (callback != null) {
                             callback.onUserCancel();
+                        }
                     }
                 });
         adialog = builder.create();
@@ -233,10 +238,12 @@ public class MultiStepResultHelper {
         @Override
         protected void onPostExecute(T res) {
             super.onPostExecute(res);
-            if (helper.pdialog != null)
+            if (helper.pdialog != null) {
                 helper.pdialog.dismiss();
-            if (res != null)
+            }
+            if (res != null) {
                 helper.handleResult(res);
+            }
         }
 
         @Override

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/NavigationAdapter.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/NavigationAdapter.java
@@ -136,9 +136,11 @@ public class NavigationAdapter extends BaseAdapter {
                 if (mData.get(position).iconDrawable != null) {
                     holder.icon.setVisibility(View.VISIBLE);
                     holder.icon.setImageDrawable(mContext.getResources()
-                            .getDrawable(mData.get(position).iconDrawable));
-                } else
+                                                         .getDrawable(
+                                                                 mData.get(position).iconDrawable));
+                } else {
                     holder.icon.setVisibility(View.INVISIBLE);
+                }
                 break;
             case Item.TYPE_ACCOUNT:
                 holder.text.setText(mData.get(position).text);

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/OpacActivity.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/OpacActivity.java
@@ -100,8 +100,9 @@ public abstract class OpacActivity extends ActionBarActivity {
     private boolean fabVisible;
 
     protected static void unbindDrawables(View view) {
-        if (view == null)
+        if (view == null) {
             return;
+        }
         if (view.getBackground() != null) {
             view.getBackground().setCallback(null);
         }
@@ -131,8 +132,9 @@ public abstract class OpacActivity extends ActionBarActivity {
 
         aData = new AccountDataSource(this);
         toolbar = (Toolbar) findViewById(R.id.toolbar);
-        if (toolbar != null)
+        if (toolbar != null) {
             setSupportActionBar(toolbar);
+        }
         fab = (FloatingActionButton) findViewById(R.id.search_fab);
         setupDrawer();
 
@@ -148,7 +150,7 @@ public abstract class OpacActivity extends ActionBarActivity {
                 fragment = (Fragment) getSupportFragmentManager().getFragment(
                         savedInstanceState, "fragment");
                 getSupportFragmentManager().beginTransaction()
-                        .replace(R.id.content_frame, fragment).commit();
+                                           .replace(R.id.content_frame, fragment).commit();
             }
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
@@ -169,30 +171,33 @@ public abstract class OpacActivity extends ActionBarActivity {
             hasDrawer = true;
             drawerLayout.setStatusBarBackground(R.color.primary_red_dark);
             drawerLayout.setDrawerShadow(R.drawable.drawer_shadow, Gravity.LEFT);
-            drawerToggle = new ActionBarDrawerToggle(this, drawerLayout, toolbar, R.string.drawer_open, R.string.drawer_close) {
-                /**
-                 * Called when a drawer has settled in a completely closed
-                 * state.
-                 */
-                @Override
-                public void onDrawerClosed(View view) {
-                    super.onDrawerClosed(view);
-                    getSupportActionBar().setTitle(mTitle);
-                }
+            drawerToggle =
+                    new ActionBarDrawerToggle(this, drawerLayout, toolbar, R.string.drawer_open,
+                            R.string.drawer_close) {
+                        /**
+                         * Called when a drawer has settled in a completely closed
+                         * state.
+                         */
+                        @Override
+                        public void onDrawerClosed(View view) {
+                            super.onDrawerClosed(view);
+                            getSupportActionBar().setTitle(mTitle);
+                        }
 
-                /** Called when a drawer has settled in a completely open state. */
-                @Override
-                public void onDrawerOpened(View drawerView) {
-                    super.onDrawerOpened(drawerView);
-                    getSupportActionBar().setTitle(
-                            app.getResources().getString(R.string.app_name));
-                    if (getCurrentFocus() != null) {
-                        InputMethodManager imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
-                        imm.hideSoftInputFromWindow(getCurrentFocus()
-                                .getWindowToken(), 0);
-                    }
-                }
-            };
+                        /** Called when a drawer has settled in a completely open state. */
+                        @Override
+                        public void onDrawerOpened(View drawerView) {
+                            super.onDrawerOpened(drawerView);
+                            getSupportActionBar().setTitle(
+                                    app.getResources().getString(R.string.app_name));
+                            if (getCurrentFocus() != null) {
+                                InputMethodManager imm = (InputMethodManager) getSystemService(
+                                        Context.INPUT_METHOD_SERVICE);
+                                imm.hideSoftInputFromWindow(getCurrentFocus()
+                                        .getWindowToken(), 0);
+                            }
+                        }
+                    };
 
             // Set the drawer toggle as the DrawerListener
             drawerLayout.setDrawerListener(drawerToggle);
@@ -281,7 +286,7 @@ public abstract class OpacActivity extends ActionBarActivity {
                                 .getDefaultSharedPreferences(OpacActivity.this);
                         drawerLayout.openDrawer(drawer);
                         sp.edit().putBoolean("version2.0.0-introduced", true)
-                                .commit();
+                          .commit();
                     }
                 }, 500);
 
@@ -293,21 +298,24 @@ public abstract class OpacActivity extends ActionBarActivity {
     protected void onPostCreate(Bundle savedInstanceState) {
         super.onPostCreate(savedInstanceState);
         setSupportProgressBarIndeterminateVisibility(false);
-        if (hasDrawer)
+        if (hasDrawer) {
             drawerToggle.syncState();
+        }
     }
 
     @Override
     public void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
-        if (hasDrawer)
+        if (hasDrawer) {
             drawerToggle.onConfigurationChanged(newConfig);
+        }
     }
 
     protected void selectItem(String tag) {
         int pos = navAdapter.getPositionByTag(tag);
-        if (pos >= 0)
+        if (pos >= 0) {
             selectItem(pos);
+        }
     }
 
     @Override
@@ -317,16 +325,18 @@ public abstract class OpacActivity extends ActionBarActivity {
         fragment = (Fragment) getSupportFragmentManager().findFragmentById(
                 R.id.content_frame);
 
-        if (hasDrawer)
+        if (hasDrawer) {
             drawerToggle.syncState();
+        }
         setTwoPane(twoPane);
         super.onResume();
         fixNavigationSelection();
     }
 
     protected void fixNavigationSelection() {
-        if (fragment == null)
+        if (fragment == null) {
             return;
+        }
         if (fragment instanceof SearchFragment) {
             drawerList.setItemChecked(navAdapter.getPositionByTag("search"),
                     true);
@@ -340,9 +350,10 @@ public abstract class OpacActivity extends ActionBarActivity {
             drawerList
                     .setItemChecked(navAdapter.getPositionByTag("info"), true);
         }
-        if (app.getLibrary() != null)
+        if (app.getLibrary() != null) {
             getSupportActionBar()
                     .setSubtitle(app.getLibrary().getDisplayName());
+        }
     }
 
     /**
@@ -392,17 +403,19 @@ public abstract class OpacActivity extends ActionBarActivity {
             // Insert the fragment by replacing any existing fragment
             FragmentManager fragmentManager = getSupportFragmentManager();
             FragmentTransaction transaction = fragmentManager.beginTransaction()
-                    .replace(R.id.content_frame, fragment);
+                                                             .replace(R.id.content_frame, fragment);
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                fragment.setSharedElementEnterTransition(TransitionInflater.from(this).inflateTransition
-                        (android.R.transition.move));
+                fragment.setSharedElementEnterTransition(
+                        TransitionInflater.from(this).inflateTransition
+                                (android.R.transition.move));
                 fragment.setEnterTransition(TransitionInflater.from(this).inflateTransition
                         (android.R.transition.fade));
             }
 
             try {
-                if (previousFragment instanceof SearchFragment && fragment instanceof AccountFragment) {
+                if (previousFragment instanceof SearchFragment &&
+                        fragment instanceof AccountFragment) {
                     transaction.addSharedElement(previousFragment.getView().findViewById(R.id
                             .rlSimpleSearch), getString(R.string.transition_gray_box));
                 } else if (previousFragment instanceof AccountFragment &&
@@ -460,8 +473,9 @@ public abstract class OpacActivity extends ActionBarActivity {
 
     protected void deselectItemsByType(int type) {
         for (int i = 0; i < navAdapter.getCount(); i++) {
-            if (navAdapter.getItemViewType(i) == type)
+            if (navAdapter.getItemViewType(i) == type) {
                 drawerList.setItemChecked(i, false);
+            }
         }
     }
 
@@ -486,8 +500,9 @@ public abstract class OpacActivity extends ActionBarActivity {
                                 .setAccount(available_accounts.get(0).getId());
                     }
                     data.close();
-                    if (app.getLibrary() != null)
+                    if (app.getLibrary() != null) {
                         return;
+                    }
                 }
             }
             app.addFirstAccount(this);
@@ -539,24 +554,24 @@ public abstract class OpacActivity extends ActionBarActivity {
             }
         });
         builder.setTitle(R.string.account_select)
-                .setView(view)
-                .setNegativeButton(R.string.cancel,
-                        new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialog, int id) {
-                                adialog.cancel();
-                            }
-                        })
-                .setNeutralButton(R.string.accounts_edit,
-                        new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialog, int id) {
-                                dialog.dismiss();
-                                Intent intent = new Intent(OpacActivity.this,
-                                        AccountListActivity.class);
-                                startActivity(intent);
-                            }
-                        });
+               .setView(view)
+               .setNegativeButton(R.string.cancel,
+                       new DialogInterface.OnClickListener() {
+                           @Override
+                           public void onClick(DialogInterface dialog, int id) {
+                               adialog.cancel();
+                           }
+                       })
+               .setNeutralButton(R.string.accounts_edit,
+                       new DialogInterface.OnClickListener() {
+                           @Override
+                           public void onClick(DialogInterface dialog, int id) {
+                               dialog.dismiss();
+                               Intent intent = new Intent(OpacActivity.this,
+                                       AccountListActivity.class);
+                               startActivity(intent);
+                           }
+                       });
         adialog = builder.create();
         adialog.show();
     }
@@ -586,8 +601,9 @@ public abstract class OpacActivity extends ActionBarActivity {
         if (isTablet()) {
             findViewById(R.id.content_frame_right).setVisibility(
                     active ? View.VISIBLE : View.GONE);
-            findViewById(R.id.twopane_wrapper).getLayoutParams().width = active ? LinearLayout.LayoutParams.MATCH_PARENT :
-                    getResources().getDimensionPixelSize(R.dimen.single_pane_max_width);
+            findViewById(R.id.twopane_wrapper).getLayoutParams().width =
+                    active ? LinearLayout.LayoutParams.MATCH_PARENT :
+                            getResources().getDimensionPixelSize(R.dimen.single_pane_max_width);
         }
     }
 
@@ -625,11 +641,13 @@ public abstract class OpacActivity extends ActionBarActivity {
         outState.putBoolean("twoPane", twoPane);
         outState.putBoolean("fabVisible", fabVisible);
         outState.putString("selectedItemTag", selectedItemTag);
-        if (fragment != null)
+        if (fragment != null) {
             getSupportFragmentManager().putFragment(outState, "fragment",
                     fragment);
-        if (mTitle != null)
+        }
+        if (mTitle != null) {
             outState.putCharSequence("title", mTitle);
+        }
     }
 
     public interface AccountSelectedListener {

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/ResultsAdapter.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/ResultsAdapter.java
@@ -194,7 +194,7 @@ public class ResultsAdapter extends ArrayAdapter<SearchResult> {
                 try {
                     float density = getContext().getResources().getDisplayMetrics().density;
                     newurl = new URL(ISBNTools.getBestSizeCoverUrl(item.getCover(),
-                            (int) (56*density), (int) (56*density)));
+                            (int) (56 * density), (int) (56 * density)));
                     Bitmap mIcon_val = BitmapFactory.decodeStream(newurl
                             .openConnection().getInputStream());
                     if (mIcon_val.getHeight() > 1 && mIcon_val.getWidth() > 1) {

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/ResultsAdapterEndless.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/ResultsAdapterEndless.java
@@ -40,7 +40,8 @@ public class ResultsAdapterEndless extends EndlessAdapter {
     private int resultCount;
     private List<SearchResult> itemsToAppend;
 
-    public ResultsAdapterEndless(Context context, SearchRequestResult result, OnLoadMoreListener listener) {
+    public ResultsAdapterEndless(Context context, SearchRequestResult result,
+                                 OnLoadMoreListener listener) {
         super(context, new ResultsAdapter(context,
                 result.getResults()), R.layout.listitem_searchresult_loading);
         this.objects = result.getResults();
@@ -73,7 +74,7 @@ public class ResultsAdapterEndless extends EndlessAdapter {
             itemsToAppend = result.getResults();
 
 			/* When IOpac finds more than 200 results, the real result count is
-			not known until the second page is loaded */
+            not known until the second page is loaded */
             maxPage = result.getPage_count();
             resultCount = result.getTotal_result_count();
 

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/SearchFragment.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/SearchFragment.java
@@ -71,6 +71,7 @@ public class SearchFragment extends Fragment implements AccountSelectedListener 
     protected String barcodeScanningField;
     protected ScanResult scanResult;
     private LoadSearchFieldsTask task;
+
     public SearchFragment() {
 
     }
@@ -128,8 +129,9 @@ public class SearchFragment extends Fragment implements AccountSelectedListener 
 
     public void clear() {
         for (SearchField field : fields) {
-            if (!field.isVisible())
+            if (!field.isVisible()) {
                 continue;
+            }
             ViewGroup v = (ViewGroup) view.findViewWithTag(field.getId());
             if (field instanceof TextSearchField) {
                 EditText text;
@@ -164,7 +166,7 @@ public class SearchFragment extends Fragment implements AccountSelectedListener 
                                 Intent i = new Intent(Intent.ACTION_VIEW, Uri
                                         .parse("market://details?id="
                                                 + app.getLibrary()
-                                                .getReplacedBy()));
+                                                     .getReplacedBy()));
                                 startActivity(i);
                             } catch (ActivityNotFoundException e) {
                                 Log.i("play", "no market installed");
@@ -203,11 +205,13 @@ public class SearchFragment extends Fragment implements AccountSelectedListener 
         tvSearchAdvHeader.setVisibility(View.GONE);
 
         int i = 0;
-        if (fields == null)
+        if (fields == null) {
             return;
+        }
         for (final SearchField field : fields) {
-            if (!field.isVisible())
+            if (!field.isVisible()) {
                 continue;
+            }
             ViewGroup v = null;
             if (field instanceof TextSearchField) {
                 TextSearchField textSearchField = (TextSearchField) field;
@@ -228,8 +232,9 @@ public class SearchFragment extends Fragment implements AccountSelectedListener 
                     }
                     if (((TextSearchField) field).isHalfWidth()
                             && i >= 1
-                            && !(fields.get(i - 1) instanceof TextSearchField && ((TextSearchField) fields
-                            .get(i - 1)).isFreeSearch())) {
+                            && !(fields.get(i - 1) instanceof TextSearchField &&
+                            ((TextSearchField) fields
+                                    .get(i - 1)).isFreeSearch())) {
                         ViewGroup before = (ViewGroup) view
                                 .findViewWithTag(fields.get(i - 1).getId());
                         llFormFields.removeView(before);
@@ -237,10 +242,11 @@ public class SearchFragment extends Fragment implements AccountSelectedListener 
                         v.setTag(field.getId());
                         View together = makeHalfWidth(before, v);
                         v = null;
-                        if (field.isAdvanced())
+                        if (field.isAdvanced()) {
                             llAdvancedFields.addView(together);
-                        else
+                        } else {
                             llFormFields.addView(together);
+                        }
                     }
                 }
             } else if (field instanceof BarcodeSearchField) {
@@ -262,8 +268,9 @@ public class SearchFragment extends Fragment implements AccountSelectedListener 
                 });
                 if (((BarcodeSearchField) field).isHalfWidth()
                         && i >= 1
-                        && !(fields.get(i - 1) instanceof TextSearchField && ((TextSearchField) fields
-                        .get(i - 1)).isFreeSearch())) {
+                        &&
+                        !(fields.get(i - 1) instanceof TextSearchField && ((TextSearchField) fields
+                                .get(i - 1)).isFreeSearch())) {
                     ViewGroup before = (ViewGroup) view.findViewWithTag(fields
                             .get(i - 1).getId());
                     llFormFields.removeView(before);
@@ -285,14 +292,14 @@ public class SearchFragment extends Fragment implements AccountSelectedListener 
                 if (field.getMeaning() == Meaning.HOME_BRANCH) {
                     String selection = "";
                     if (sp.contains(OpacClient.PREF_HOME_BRANCH_PREFIX
-                            + app.getAccount().getId()))
+                            + app.getAccount().getId())) {
                         selection = sp.getString(
                                 OpacClient.PREF_HOME_BRANCH_PREFIX
                                         + app.getAccount().getId(), "");
-                    else {
+                    } else {
                         try {
                             selection = app.getLibrary().getData()
-                                    .getString("homebranch");
+                                           .getString("homebranch");
                         } catch (JSONException e) {
                             selection = "";
                         }
@@ -317,10 +324,11 @@ public class SearchFragment extends Fragment implements AccountSelectedListener 
             }
             if (v != null) {
                 v.setTag(field.getId());
-                if (field.isAdvanced())
+                if (field.isAdvanced()) {
                     llAdvancedFields.addView(v);
-                else
+                } else {
                     llFormFields.addView(v);
+                }
             }
             i++;
         }
@@ -348,7 +356,7 @@ public class SearchFragment extends Fragment implements AccountSelectedListener 
                         @Override
                         public void onGlobalLayout() {
                             rlOuter.getViewTreeObserver()
-                                    .removeGlobalOnLayoutListener(this);
+                                   .removeGlobalOnLayoutListener(this);
                             scroll.smoothScrollTo(0, llExpand.getTop());
                         }
                     });
@@ -398,15 +406,17 @@ public class SearchFragment extends Fragment implements AccountSelectedListener 
                 .getLanguage();
         if (dataSource.hasSearchFields(app.getLibrary().getIdent())
                 && dataSource.getLastSearchFieldUpdateVersion(app.getLibrary()
-                .getIdent()) == versionCode
+                                                                 .getIdent()) == versionCode
                 && language.equals(dataSource.getSearchFieldLanguage(app
                 .getLibrary().getIdent()))) {
-            if (task != null && !task.isCancelled())
+            if (task != null && !task.isCancelled()) {
                 task.cancel(true);
+            }
             fields = dataSource.getSearchFields(app.getLibrary().getIdent());
             buildSearchForm();
-            if (savedState != null)
+            if (savedState != null) {
                 loadQuery(savedState);
+            }
         } else {
             executeNewLoadSearchFieldsTask();
         }
@@ -425,8 +435,9 @@ public class SearchFragment extends Fragment implements AccountSelectedListener 
     }
 
     public void showConnectivityError(String description) {
-        if (getView() == null || getActivity() == null)
+        if (getView() == null || getActivity() == null) {
             return;
+        }
         final ViewGroup errorView = (ViewGroup) view
                 .findViewById(R.id.error_view);
         errorView.removeAllViews();
@@ -456,8 +467,9 @@ public class SearchFragment extends Fragment implements AccountSelectedListener 
     }
 
     private void executeNewLoadSearchFieldsTask() {
-        if (task != null && !task.isCancelled())
+        if (task != null && !task.isCancelled()) {
             task.cancel(true);
+        }
         task = new LoadSearchFieldsTask();
         task.execute();
     }
@@ -471,8 +483,9 @@ public class SearchFragment extends Fragment implements AccountSelectedListener 
     }
 
     public Map<String, String> saveQuery() {
-        if (app.getLibrary() == null)
+        if (app.getLibrary() == null) {
             return null;
+        }
 
         saveHomeBranch();
         Map<String, String> query = new HashMap<String, String>();
@@ -491,8 +504,9 @@ public class SearchFragment extends Fragment implements AccountSelectedListener 
             if (dataSource.hasSearchFields(app.getLibrary().getIdent())
                     && dataSource.getLastSearchFieldUpdateVersion(app
                     .getLibrary().getIdent()) == versionCode) {
-                if (task != null && !task.isCancelled())
+                if (task != null && !task.isCancelled()) {
                     task.cancel(true);
+                }
                 fields = dataSource
                         .getSearchFields(app.getLibrary().getIdent());
             } else {
@@ -501,12 +515,14 @@ public class SearchFragment extends Fragment implements AccountSelectedListener 
         }
 
         for (SearchField field : fields) {
-            if (!field.isVisible())
+            if (!field.isVisible()) {
                 continue;
+            }
 
             ViewGroup v = (ViewGroup) view.findViewWithTag(field.getId());
-            if (v == null)
+            if (v == null) {
                 return null;
+            }
             if (field instanceof TextSearchField) {
                 EditText text;
                 if (((TextSearchField) field).isFreeSearch()) {
@@ -520,11 +536,12 @@ public class SearchFragment extends Fragment implements AccountSelectedListener 
                 query.put(field.getId(), text.getEditableText().toString());
             } else if (field instanceof DropdownSearchField) {
                 Spinner spinner = (Spinner) v.findViewById(R.id.spinner);
-                if (spinner.getSelectedItemPosition() > 0)
+                if (spinner.getSelectedItemPosition() > 0) {
                     query.put(field.getId(),
                             ((DropdownSearchField) field).getDropdownValues()
-                                    .get(spinner.getSelectedItemPosition())
-                                    .get("key"));
+                                                         .get(spinner.getSelectedItemPosition())
+                                                         .get("key"));
+                }
             } else if (field instanceof CheckboxSearchField) {
                 CheckBox checkbox = (CheckBox) v.findViewById(R.id.checkbox);
                 query.put(field.getId(), String.valueOf(checkbox.isChecked()));
@@ -536,11 +553,13 @@ public class SearchFragment extends Fragment implements AccountSelectedListener 
     public List<SearchQuery> saveSearchQuery() {
         saveHomeBranch();
         List<SearchQuery> query = new ArrayList<SearchQuery>();
-        if (fields == null)
+        if (fields == null) {
             return null;
+        }
         for (SearchField field : fields) {
-            if (!field.isVisible())
+            if (!field.isVisible()) {
                 continue;
+            }
             ViewGroup v = (ViewGroup) view.findViewWithTag(field.getId());
             if (field instanceof TextSearchField) {
                 EditText text;
@@ -550,19 +569,20 @@ public class SearchFragment extends Fragment implements AccountSelectedListener 
                     text = (EditText) v.findViewById(R.id.edittext);
                 }
                 query.add(new SearchQuery(field, text.getEditableText()
-                        .toString()));
+                                                     .toString()));
             } else if (field instanceof BarcodeSearchField) {
                 EditText text = (EditText) v.findViewById(R.id.edittext);
                 query.add(new SearchQuery(field, text.getEditableText()
-                        .toString()));
+                                                     .toString()));
             } else if (field instanceof DropdownSearchField) {
                 Spinner spinner = (Spinner) v.findViewById(R.id.spinner);
                 if (spinner.getSelectedItemPosition() != -1) {
                     String key = ((DropdownSearchField) field)
                             .getDropdownValues()
                             .get(spinner.getSelectedItemPosition()).get("key");
-                    if (!key.equals(""))
+                    if (!key.equals("")) {
                         query.add(new SearchQuery(field, key));
+                    }
                 }
             } else if (field instanceof CheckboxSearchField) {
                 CheckBox checkbox = (CheckBox) v.findViewById(R.id.checkbox);
@@ -574,12 +594,14 @@ public class SearchFragment extends Fragment implements AccountSelectedListener 
     }
 
     private void saveHomeBranch() {
-        if (fields == null)
+        if (fields == null) {
             return;
+        }
 
         for (SearchField field : fields) {
-            if (!field.isVisible())
+            if (!field.isVisible()) {
                 continue;
+            }
             if (field instanceof DropdownSearchField
                     && field.getMeaning() == Meaning.HOME_BRANCH) {
                 ViewGroup v = (ViewGroup) view.findViewWithTag(field.getId());
@@ -589,10 +611,10 @@ public class SearchFragment extends Fragment implements AccountSelectedListener 
                         .get(spinner.getSelectedItemPosition()).get("key");
                 if (!homeBranch.equals("")) {
                     sp.edit()
-                            .putString(
-                                    OpacClient.PREF_HOME_BRANCH_PREFIX
-                                            + app.getAccount().getId(),
-                                    homeBranch).commit();
+                      .putString(
+                              OpacClient.PREF_HOME_BRANCH_PREFIX
+                                      + app.getAccount().getId(),
+                              homeBranch).commit();
                 }
                 return;
             }
@@ -601,8 +623,9 @@ public class SearchFragment extends Fragment implements AccountSelectedListener 
 
     public void loadQuery(Bundle query) {
         for (SearchField field : fields) {
-            if (!field.isVisible())
+            if (!field.isVisible()) {
                 continue;
+            }
             ViewGroup v = (ViewGroup) view.findViewWithTag(field.getId());
             if (field instanceof TextSearchField) {
                 EditText text;
@@ -658,8 +681,10 @@ public class SearchFragment extends Fragment implements AccountSelectedListener 
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
         inflater.inflate(R.menu.fragment_search, menu);
         if (((OpacActivity) getActivity()).isTablet())
-            // We have the floating action button for that
+        // We have the floating action button for that
+        {
             menu.findItem(R.id.action_search_go).setVisible(false);
+        }
         super.onCreateOptionsMenu(menu, inflater);
     }
 
@@ -678,8 +703,9 @@ public class SearchFragment extends Fragment implements AccountSelectedListener 
     public void onSaveInstanceState(Bundle outState) {
         savedState = OpacClient.mapToBundle(saveQuery());
         outState.putBundle("query", savedState);
-        if (barcodeScanningField != null)
+        if (barcodeScanningField != null) {
             outState.putString("barcodeScanningField", barcodeScanningField);
+        }
         super.onSaveInstanceState(outState);
     }
 
@@ -713,11 +739,13 @@ public class SearchFragment extends Fragment implements AccountSelectedListener 
         protected List<SearchField> doInBackground(Void... arg0) {
             try {
                 List<SearchField> fields = app.getApi().getSearchFields();
-                if (getActivity() == null)
+                if (getActivity() == null) {
                     return null;
-                if (fields.size() == 0)
+                }
+                if (fields.size() == 0) {
                     throw new OpacErrorException(
                             getString(R.string.no_fields_found));
+                }
                 if (app.getApi().shouldUseMeaningDetector()) {
                     MeaningDetector md = new AndroidMeaningDetector(
                             getActivity(), app.getLibrary());
@@ -747,23 +775,26 @@ public class SearchFragment extends Fragment implements AccountSelectedListener 
 
         @Override
         protected void onPostExecute(List<SearchField> fields) {
-            if (getActivity() == null)
+            if (getActivity() == null) {
                 return;
+            }
             progress(false);
             if (fields != null) {
                 SearchFragment.this.fields = fields;
                 buildSearchForm();
-                if (savedState != null)
+                if (savedState != null) {
                     loadQuery(savedState);
+                }
             } else {
                 if (exception != null
-                        && exception instanceof OpacErrorException)
+                        && exception instanceof OpacErrorException) {
                     showConnectivityError(exception.getMessage());
-                else if (exception != null
-                        && exception instanceof SSLSecurityException)
+                } else if (exception != null
+                        && exception instanceof SSLSecurityException) {
                     showConnectivityError(getString(R.string.connection_error_detail_security));
-                else
+                } else {
                     showConnectivityError();
+                }
             }
         }
 

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/SearchResultDetailActivity.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/SearchResultDetailActivity.java
@@ -5,15 +5,15 @@ import android.os.Bundle;
 import de.geeksfactory.opacclient.R;
 
 /**
- * An activity representing a single SearchResult detail screen. This activity
- * is only used on handset devices. On tablet-size devices, item details are
- * presented side-by-side with a list of items in a
- * {@link SearchResultListActivity}.
+ * An activity representing a single SearchResult detail screen. This activity is only used on
+ * handset devices. On tablet-size devices, item details are presented side-by-side with a list of
+ * items in a {@link SearchResultListActivity}.
  * <p/>
- * This activity is mostly just a 'shell' activity containing nothing more than
- * a {@link SearchResultDetailFragment}.
+ * This activity is mostly just a 'shell' activity containing nothing more than a {@link
+ * SearchResultDetailFragment}.
  */
-public class SearchResultDetailActivity extends OpacActivity implements SearchResultDetailFragment.Callbacks {
+public class SearchResultDetailActivity extends OpacActivity
+        implements SearchResultDetailFragment.Callbacks {
 
     SearchResultDetailFragment detailFragment;
 
@@ -39,18 +39,22 @@ public class SearchResultDetailActivity extends OpacActivity implements SearchRe
                     getIntent().getIntExtra(
                             SearchResultDetailFragment.ARG_ITEM_NR, 0));
             if (getIntent().hasExtra(
-                    SearchResultDetailFragment.ARG_ITEM_ID))
+                    SearchResultDetailFragment.ARG_ITEM_ID)) {
                 arguments.putString(
                         SearchResultDetailFragment.ARG_ITEM_ID,
                         getIntent().getStringExtra(
                                 SearchResultDetailFragment.ARG_ITEM_ID));
+            }
             if (getIntent().hasExtra(SearchResultDetailFragment.ARG_ITEM_COVER_BITMAP)) {
-                arguments.putParcelable(SearchResultDetailFragment.ARG_ITEM_COVER_BITMAP, getIntent().getParcelableExtra(SearchResultDetailFragment.ARG_ITEM_COVER_BITMAP));
+                arguments.putParcelable(SearchResultDetailFragment.ARG_ITEM_COVER_BITMAP,
+                        getIntent().getParcelableExtra(
+                                SearchResultDetailFragment.ARG_ITEM_COVER_BITMAP));
             }
             detailFragment = new SearchResultDetailFragment();
             detailFragment.setArguments(arguments);
             getSupportFragmentManager().beginTransaction()
-                    .add(R.id.searchresult_detail_container, detailFragment).commit();
+                                       .add(R.id.searchresult_detail_container, detailFragment)
+                                       .commit();
         }
     }
 

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/SearchResultDetailFragment.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/SearchResultDetailFragment.java
@@ -73,22 +73,22 @@ import de.geeksfactory.opacclient.ui.WhitenessUtils;
 import de.geeksfactory.opacclient.utils.ISBNTools;
 
 /**
- * A fragment representing a single SearchResult detail screen. This fragment is
- * either contained in a {@link SearchResultListActivity} in two-pane mode (on
- * tablets) or a {@link SearchResultDetailActivity} on handsets.
+ * A fragment representing a single SearchResult detail screen. This fragment is either contained in
+ * a {@link SearchResultListActivity} in two-pane mode (on tablets) or a {@link
+ * SearchResultDetailActivity} on handsets.
  */
-public class SearchResultDetailFragment extends Fragment implements Toolbar.OnMenuItemClickListener, ObservableScrollView.Callbacks {
+public class SearchResultDetailFragment extends Fragment
+        implements Toolbar.OnMenuItemClickListener, ObservableScrollView.Callbacks {
     /**
-     * The fragment argument representing the item ID that this fragment
-     * represents.
+     * The fragment argument representing the item ID that this fragment represents.
      */
     public static final String ARG_ITEM_ID = "item_id";
 
     public static final String ARG_ITEM_NR = "item_nr";
     public static final String ARG_ITEM_COVER_BITMAP = "item_cover_bitmap";
     /**
-     * A dummy implementation of the {@link Callbacks} interface that does
-     * nothing. Used only when this fragment is not attached to an activity.
+     * A dummy implementation of the {@link Callbacks} interface that does nothing. Used only when
+     * this fragment is not attached to an activity.
      */
     private static Callbacks sDummyCallbacks = new Callbacks() {
         @Override
@@ -96,8 +96,7 @@ public class SearchResultDetailFragment extends Fragment implements Toolbar.OnMe
         }
     };
     /**
-     * The fragment's current callback object, which is notified of list item
-     * clicks.
+     * The fragment's current callback object, which is notified of list item clicks.
      */
     private Callbacks mCallbacks = sDummyCallbacks;
     protected boolean back_button_visible = false;
@@ -130,8 +129,8 @@ public class SearchResultDetailFragment extends Fragment implements Toolbar.OnMe
     private Boolean[] cardAnimations;
 
     /**
-     * Mandatory empty constructor for the fragment manager to instantiate the
-     * fragment (e.g. upon screen orientation changes).
+     * Mandatory empty constructor for the fragment manager to instantiate the fragment (e.g. upon
+     * screen orientation changes).
      */
     public SearchResultDetailFragment() {
     }
@@ -158,8 +157,9 @@ public class SearchResultDetailFragment extends Fragment implements Toolbar.OnMe
             ProgressBar progress = (ProgressBar) view
                     .findViewById(R.id.progress);
             View content = view.findViewById(R.id.detailsLayout);
-            if (scrollView != null)
+            if (scrollView != null) {
                 scrollView.setVisibility(View.VISIBLE);
+            }
 
             if (show) {
                 if (animate) {
@@ -337,43 +337,45 @@ public class SearchResultDetailFragment extends Fragment implements Toolbar.OnMe
     }
 
     /**
-     * Workaround because the built-in ellipsize function does not work for multiline TextViews
-     * This function is only prepared for one or two lines
+     * Workaround because the built-in ellipsize function does not work for multiline TextViews This
+     * function is only prepared for one or two lines
      *
      * @param tv The TextView to fix
      */
     private void fixEllipsize(final TextView tv) {
-        tv.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
+        tv.getViewTreeObserver()
+          .addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
 
-            @Override
-            public void onGlobalLayout() {
-                if (tv.getLineCount() > 2) {
-                    try {
-                        int lineEndIndex = tv.getLayout().getLineEnd(1);
-                        String text = tv.getText().subSequence(0, lineEndIndex - 3) + "...";
-                        tv.setText(text);
-                    } catch (StringIndexOutOfBoundsException e) {
-                        // Happens in strange cases where the second line is less than three
-                        // characters long
-                        e.printStackTrace();
-                    }
-                }
-            }
-        });
+              @Override
+              public void onGlobalLayout() {
+                  if (tv.getLineCount() > 2) {
+                      try {
+                          int lineEndIndex = tv.getLayout().getLineEnd(1);
+                          String text = tv.getText().subSequence(0, lineEndIndex - 3) + "...";
+                          tv.setText(text);
+                      } catch (StringIndexOutOfBoundsException e) {
+                          // Happens in strange cases where the second line is less than three
+                          // characters long
+                          e.printStackTrace();
+                      }
+                  }
+              }
+          });
     }
 
     /**
-     * Examine how many white pixels are in the bitmap in order to determine whether or not
-     * we need gradient overlays on top of the image.
+     * Examine how many white pixels are in the bitmap in order to determine whether or not we need
+     * gradient overlays on top of the image.
      */
     @SuppressLint("NewApi")
     private void analyzeWhitenessOfCoverAsync(final Bitmap bitmap) {
         AnalyzeWhitenessTask task = new AnalyzeWhitenessTask();
         // Execute in parallel with FetchTask
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
             task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, bitmap);
-        else
+        } else {
             task.execute(bitmap);
+        }
     }
 
     protected void display() {
@@ -387,16 +389,17 @@ public class SearchResultDetailFragment extends Fragment implements Toolbar.OnMe
             ivCover.setVisibility(View.VISIBLE);
             ivCover.setImageBitmap(getItem().getCoverBitmap());
             if (!image_analyzed) {
-                Palette.generateAsync(getItem().getCoverBitmap(), new Palette.PaletteAsyncListener() {
-                    @Override
-                    public void onGenerated(Palette palette) {
-                        Palette.Swatch swatch = palette.getDarkVibrantSwatch();
-                        if (swatch != null) {
-                            ivCover.setBackgroundColor(swatch.getRgb());
-                            tint.setBackgroundColor(swatch.getRgb());
-                        }
-                    }
-                });
+                Palette.generateAsync(getItem().getCoverBitmap(),
+                        new Palette.PaletteAsyncListener() {
+                            @Override
+                            public void onGenerated(Palette palette) {
+                                Palette.Swatch swatch = palette.getDarkVibrantSwatch();
+                                if (swatch != null) {
+                                    ivCover.setBackgroundColor(swatch.getRgb());
+                                    tint.setBackgroundColor(swatch.getRgb());
+                                }
+                            }
+                        });
                 analyzeWhitenessOfCoverAsync(getItem().getCoverBitmap());
             }
             tvTitel.setText(getItem().getTitle());
@@ -588,35 +591,75 @@ public class SearchResultDetailFragment extends Fragment implements Toolbar.OnMe
             // tvTitel is used for displaying title
             fixTitleWidth();
             tvTitel.getViewTreeObserver().addOnGlobalLayoutListener(new
-                                                                            ViewTreeObserver.OnGlobalLayoutListener() {
+                                                                            ViewTreeObserver
+                                                                                    .OnGlobalLayoutListener() {
                                                                                 @Override
-                                                                                public void onGlobalLayout() {
-                                                                                    // We need to wait for tvTitel to refresh to get correct calculations
-                                                                                    tvTitel.getViewTreeObserver().removeGlobalOnLayoutListener(this);
-                                                                                    if (tvTitel.getLayout().getLineCount() > 1) {
-                                                                                        toolbar.getLayoutParams().height = (int) TypedValue
-                                                                                                .applyDimension(TypedValue.COMPLEX_UNIT_SP, 84f,
-                                                                                                        getResources().getDisplayMetrics());
-                                                                                        toolbar.getParent().requestLayout();
+                                                                                public void
+                                                                                onGlobalLayout() {
+                                                                                    // We need to
+                                                                                    // wait for
+                                                                                    // tvTitel to
+                                                                                    // refresh to
+                                                                                    // get
+                                                                                    // correct
+                                                                                    // calculations
+                                                                                    tvTitel.getViewTreeObserver()
+                                                                                           .removeGlobalOnLayoutListener(
+                                                                                                   this);
+                                                                                    if (tvTitel
+                                                                                            .getLayout()
+                                                                                            .getLineCount() >
+                                                                                            1) {
+                                                                                        toolbar.getLayoutParams().height =
+                                                                                                (int) TypedValue
+                                                                                                        .applyDimension(
+                                                                                                                TypedValue.COMPLEX_UNIT_SP,
+                                                                                                                84f,
+                                                                                                                getResources()
+                                                                                                                        .getDisplayMetrics());
+                                                                                        toolbar.getParent()
+                                                                                               .requestLayout();
                                                                                     }
                                                                                 }
                                                                             });
         } else {
             // Toolbar is used for displaying title
             toolbar.getViewTreeObserver().addOnGlobalLayoutListener(new
-                                                                            ViewTreeObserver.OnGlobalLayoutListener() {
+                                                                            ViewTreeObserver
+                                                                                    .OnGlobalLayoutListener() {
                                                                                 @Override
-                                                                                public void onGlobalLayout() {
-                                                                                    // We need to wait for toolbar to refresh to get correct calculations
-                                                                                    toolbar.getViewTreeObserver().removeGlobalOnLayoutListener(this);
-                                                                                    if (toolbar.isTitleTruncated()) {
-                                                                                        toolbar.getLayoutParams().height = (int) TypedValue
-                                                                                                .applyDimension(TypedValue.COMPLEX_UNIT_SP, 84f,
-                                                                                                        getResources().getDisplayMetrics());
-                                                                                        TextView titleTextView = findTitleTextView(toolbar);
-                                                                                        titleTextView.setSingleLine(false);
-                                                                                        fixEllipsize(titleTextView);
-                                                                                        toolbar.getParent().requestLayout();
+                                                                                public void
+                                                                                onGlobalLayout() {
+                                                                                    // We need to
+                                                                                    // wait for
+                                                                                    // toolbar to
+                                                                                    // refresh to
+                                                                                    // get
+                                                                                    // correct
+                                                                                    // calculations
+                                                                                    toolbar.getViewTreeObserver()
+                                                                                           .removeGlobalOnLayoutListener(
+                                                                                                   this);
+                                                                                    if (toolbar
+                                                                                            .isTitleTruncated()) {
+                                                                                        toolbar.getLayoutParams().height =
+                                                                                                (int) TypedValue
+                                                                                                        .applyDimension(
+                                                                                                                TypedValue.COMPLEX_UNIT_SP,
+                                                                                                                84f,
+                                                                                                                getResources()
+                                                                                                                        .getDisplayMetrics());
+                                                                                        TextView
+                                                                                                titleTextView =
+                                                                                                findTitleTextView(
+                                                                                                        toolbar);
+                                                                                        titleTextView
+                                                                                                .setSingleLine(
+                                                                                                        false);
+                                                                                        fixEllipsize(
+                                                                                                titleTextView);
+                                                                                        toolbar.getParent()
+                                                                                               .requestLayout();
                                                                                     }
                                                                                 }
                                                                             });
@@ -648,16 +691,16 @@ public class SearchResultDetailFragment extends Fragment implements Toolbar.OnMe
     private ActionMenuView findActionMenuView(Toolbar toolbar) {
         for (int i = 0; i < toolbar.getChildCount(); i++) {
             View view = toolbar.getChildAt(i);
-            if (view instanceof ActionMenuView)
+            if (view instanceof ActionMenuView) {
                 return (ActionMenuView) view;
+            }
         }
         return null;
     }
 
     /**
      * Hacky way to find the first {@link android.widget.TextView} inside a {@link android
-     * .support.v7.widget.Toolbar}, wnich is typically the title. Will return null if none
-     * is found
+     * .support.v7.widget.Toolbar}, wnich is typically the title. Will return null if none is found
      *
      * @param toolbar a Toolbar
      * @return the first TextView inside this toolbar, or null if none is found
@@ -665,8 +708,9 @@ public class SearchResultDetailFragment extends Fragment implements Toolbar.OnMe
     private TextView findTitleTextView(Toolbar toolbar) {
         for (int i = 0; i < toolbar.getChildCount(); i++) {
             View view = toolbar.getChildAt(i);
-            if (view instanceof TextView)
+            if (view instanceof TextView) {
                 return (TextView) view;
+            }
         }
         return null;
     }
@@ -743,37 +787,40 @@ public class SearchResultDetailFragment extends Fragment implements Toolbar.OnMe
     @Override
     public void onViewStateRestored(Bundle savedInstanceState) {
         super.onViewStateRestored(savedInstanceState);
-        if (item != null)
+        if (item != null) {
             display();
+        }
     }
 
     protected void dialog_wrong_credentials(String s, final boolean finish) {
-        if (getActivity() == null)
+        if (getActivity() == null) {
             return;
+        }
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
         builder.setMessage(getString(R.string.opac_error) + " " + s)
-                .setCancelable(false)
-                .setNegativeButton(R.string.close,
-                        new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialog, int id) {
-                                dialog.cancel();
-                                if (finish)
-                                    mCallbacks.removeFragment();
-                            }
-                        })
-                .setPositiveButton(R.string.prefs,
-                        new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialog, int id) {
-                                Intent intent = new Intent(getActivity(),
-                                        AccountEditActivity.class);
-                                intent.putExtra(
-                                        AccountEditActivity.EXTRA_ACCOUNT_ID,
-                                        app.getAccount().getId());
-                                startActivity(intent);
-                            }
-                        });
+               .setCancelable(false)
+               .setNegativeButton(R.string.close,
+                       new DialogInterface.OnClickListener() {
+                           @Override
+                           public void onClick(DialogInterface dialog, int id) {
+                               dialog.cancel();
+                               if (finish) {
+                                   mCallbacks.removeFragment();
+                               }
+                           }
+                       })
+               .setPositiveButton(R.string.prefs,
+                       new DialogInterface.OnClickListener() {
+                           @Override
+                           public void onClick(DialogInterface dialog, int id) {
+                               Intent intent = new Intent(getActivity(),
+                                       AccountEditActivity.class);
+                               intent.putExtra(
+                                       AccountEditActivity.EXTRA_ACCOUNT_ID,
+                                       app.getAccount().getId());
+                               startActivity(intent);
+                           }
+                       });
         AlertDialog alert = builder.create();
         alert.show();
     }
@@ -824,10 +871,11 @@ public class SearchResultDetailFragment extends Fragment implements Toolbar.OnMe
                 menu.findItem(R.id.action_reservation).setVisible(false);
             }
             if (item.isBookable() && app.getApi() instanceof EbookServiceApi) {
-                if (((EbookServiceApi) app.getApi()).isEbook(item))
+                if (((EbookServiceApi) app.getApi()).isEbook(item)) {
                     menu.findItem(R.id.action_lendebook).setVisible(true);
-                else
+                } else {
                     menu.findItem(R.id.action_lendebook).setVisible(false);
+                }
             } else {
                 menu.findItem(R.id.action_lendebook).setVisible(false);
             }
@@ -956,16 +1004,18 @@ public class SearchResultDetailFragment extends Fragment implements Toolbar.OnMe
 
                             for (Detail detail : getItem().getDetails()) {
                                 String colon = "";
-                                if (!detail.getDesc().endsWith(":"))
+                                if (!detail.getDesc().endsWith(":")) {
                                     colon = ":";
+                                }
                                 text += detail.getDesc() + colon + "\n"
                                         + detail.getContent() + "\n\n";
                             }
 
                             String shareUrl = app.getApi().getShareUrl(id,
                                     title);
-                            if (shareUrl != null)
+                            if (shareUrl != null) {
                                 text += shareUrl;
+                            }
 
                             intent.putExtra(Intent.EXTRA_TEXT, text);
                             startActivity(Intent.createChooser(intent,
@@ -1023,30 +1073,31 @@ public class SearchResultDetailFragment extends Fragment implements Toolbar.OnMe
     }
 
     protected void dialog_no_credentials() {
-        if (getActivity() == null)
+        if (getActivity() == null) {
             return;
+        }
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
         builder.setMessage(R.string.status_nouser)
-                .setCancelable(false)
-                .setNegativeButton(R.string.close,
-                        new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialog, int id) {
-                                dialog.cancel();
-                            }
-                        })
-                .setPositiveButton(R.string.accounts_edit,
-                        new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialog, int id) {
-                                Intent intent = new Intent(getActivity(),
-                                        AccountEditActivity.class);
-                                intent.putExtra(
-                                        AccountEditActivity.EXTRA_ACCOUNT_ID,
-                                        app.getAccount().getId());
-                                startActivity(intent);
-                            }
-                        });
+               .setCancelable(false)
+               .setNegativeButton(R.string.close,
+                       new DialogInterface.OnClickListener() {
+                           @Override
+                           public void onClick(DialogInterface dialog, int id) {
+                               dialog.cancel();
+                           }
+                       })
+               .setPositiveButton(R.string.accounts_edit,
+                       new DialogInterface.OnClickListener() {
+                           @Override
+                           public void onClick(DialogInterface dialog, int id) {
+                               Intent intent = new Intent(getActivity(),
+                                       AccountEditActivity.class);
+                               intent.putExtra(
+                                       AccountEditActivity.EXTRA_ACCOUNT_ID,
+                                       app.getAccount().getId());
+                               startActivity(intent);
+                           }
+                       });
         AlertDialog alert = builder.create();
         alert.show();
     }
@@ -1063,24 +1114,24 @@ public class SearchResultDetailFragment extends Fragment implements Toolbar.OnMe
                 AlertDialog.Builder builder = new AlertDialog.Builder(
                         getActivity());
                 builder.setMessage(getString(R.string.opac_error_email))
-                        .setCancelable(false)
-                        .setNegativeButton(R.string.close,
-                                new DialogInterface.OnClickListener() {
-                                    @Override
-                                    public void onClick(DialogInterface dialog,
-                                                        int id) {
-                                        dialog.cancel();
-                                    }
-                                })
-                        .setPositiveButton(R.string.prefs,
-                                new DialogInterface.OnClickListener() {
-                                    @Override
-                                    public void onClick(DialogInterface dialog,
-                                                        int id) {
-                                        dialog.dismiss();
-                                        app.toPrefs(getActivity());
-                                    }
-                                });
+                       .setCancelable(false)
+                       .setNegativeButton(R.string.close,
+                               new DialogInterface.OnClickListener() {
+                                   @Override
+                                   public void onClick(DialogInterface dialog,
+                                                       int id) {
+                                       dialog.cancel();
+                                   }
+                               })
+                       .setPositiveButton(R.string.prefs,
+                               new DialogInterface.OnClickListener() {
+                                   @Override
+                                   public void onClick(DialogInterface dialog,
+                                                       int id) {
+                                       dialog.dismiss();
+                                       app.toPrefs(getActivity());
+                                   }
+                               });
                 AlertDialog alert = builder.create();
                 alert.show();
                 return;
@@ -1100,8 +1151,9 @@ public class SearchResultDetailFragment extends Fragment implements Toolbar.OnMe
                 false)
                 && (app.getApi().getSupportFlags() & OpacApi.SUPPORT_FLAG_CHANGE_ACCOUNT) != 0
                 && !(SearchResultDetailFragment.this.id == null
-                || SearchResultDetailFragment.this.id.equals("null") || SearchResultDetailFragment.this.id
-                .equals(""))) {
+                || SearchResultDetailFragment.this.id.equals("null") ||
+                SearchResultDetailFragment.this.id
+                        .equals(""))) {
             AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
             // Get the layout inflater
             LayoutInflater inflater = getLayoutInflater(null);
@@ -1117,7 +1169,7 @@ public class SearchResultDetailFragment extends Fragment implements Toolbar.OnMe
                 public void onItemClick(AdapterView<?> parent, View view,
                                         int position, long id) {
                     if (accounts.get(position).getId() != app.getAccount()
-                            .getId() || account_switched) {
+                                                             .getId() || account_switched) {
 
                         if (SearchResultDetailFragment.this.id == null
                                 || SearchResultDetailFragment.this.id
@@ -1126,7 +1178,7 @@ public class SearchResultDetailFragment extends Fragment implements Toolbar.OnMe
                                 .equals("")) {
                             Toast.makeText(getActivity(),
                                     R.string.accchange_sorry, Toast.LENGTH_LONG)
-                                    .show();
+                                 .show();
                         } else {
                             app.setAccount(accounts.get(position).getId());
                             Intent intent = new Intent(getActivity(),
@@ -1145,15 +1197,15 @@ public class SearchResultDetailFragment extends Fragment implements Toolbar.OnMe
                 }
             });
             builder.setTitle(R.string.account_select)
-                    .setView(view)
-                    .setNegativeButton(R.string.cancel,
-                            new DialogInterface.OnClickListener() {
-                                @Override
-                                public void onClick(DialogInterface dialog,
-                                                    int id) {
-                                    adialog.cancel();
-                                }
-                            });
+                   .setView(view)
+                   .setNegativeButton(R.string.cancel,
+                           new DialogInterface.OnClickListener() {
+                               @Override
+                               public void onClick(DialogInterface dialog,
+                                                   int id) {
+                                   adialog.cancel();
+                               }
+                           });
             adialog = builder.create();
             adialog.show();
         } else {
@@ -1175,29 +1227,29 @@ public class SearchResultDetailFragment extends Fragment implements Toolbar.OnMe
                     AlertDialog.Builder builder = new AlertDialog.Builder(
                             getActivity());
                     builder.setMessage(result.getMessage())
-                            .setCancelable(false)
-                            .setNegativeButton(R.string.close,
-                                    new DialogInterface.OnClickListener() {
-                                        @Override
-                                        public void onClick(
-                                                DialogInterface dialog, int id) {
-                                            dialog.cancel();
-                                        }
-                                    })
-                            .setPositiveButton(R.string.account,
-                                    new DialogInterface.OnClickListener() {
-                                        @Override
-                                        public void onClick(
-                                                DialogInterface dialog, int id) {
-                                            Intent intent = new Intent(
-                                                    getActivity(), app
-                                                    .getMainActivity());
-                                            intent.putExtra("fragment",
-                                                    "account");
-                                            getActivity().startActivity(intent);
-                                            getActivity().finish();
-                                        }
-                                    });
+                           .setCancelable(false)
+                           .setNegativeButton(R.string.close,
+                                   new DialogInterface.OnClickListener() {
+                                       @Override
+                                       public void onClick(
+                                               DialogInterface dialog, int id) {
+                                           dialog.cancel();
+                                       }
+                                   })
+                           .setPositiveButton(R.string.account,
+                                   new DialogInterface.OnClickListener() {
+                                       @Override
+                                       public void onClick(
+                                               DialogInterface dialog, int id) {
+                                           Intent intent = new Intent(
+                                                   getActivity(), app
+                                                   .getMainActivity());
+                                           intent.putExtra("fragment",
+                                                   "account");
+                                           getActivity().startActivity(intent);
+                                           getActivity().finish();
+                                       }
+                                   });
                     AlertDialog alert = builder.create();
                     alert.show();
                 } else {
@@ -1260,15 +1312,15 @@ public class SearchResultDetailFragment extends Fragment implements Toolbar.OnMe
                 }
             });
             builder.setTitle(R.string.account_select)
-                    .setView(view)
-                    .setNegativeButton(R.string.cancel,
-                            new DialogInterface.OnClickListener() {
-                                @Override
-                                public void onClick(DialogInterface dialog,
-                                                    int id) {
-                                    adialog.cancel();
-                                }
-                            });
+                   .setView(view)
+                   .setNegativeButton(R.string.cancel,
+                           new DialogInterface.OnClickListener() {
+                               @Override
+                               public void onClick(DialogInterface dialog,
+                                                   int id) {
+                                   adialog.cancel();
+                               }
+                           });
             adialog = builder.create();
             adialog.show();
         } else {
@@ -1282,8 +1334,9 @@ public class SearchResultDetailFragment extends Fragment implements Toolbar.OnMe
         msrhBooking.setCallback(new Callback() {
             @Override
             public void onSuccess(MultiStepResult result) {
-                if (getActivity() == null)
+                if (getActivity() == null) {
                     return;
+                }
                 AccountDataSource adata = new AccountDataSource(getActivity());
                 adata.open();
                 adata.invalidateCachedAccountData(app.getAccount());
@@ -1296,8 +1349,9 @@ public class SearchResultDetailFragment extends Fragment implements Toolbar.OnMe
 
             @Override
             public void onError(MultiStepResult result) {
-                if (getActivity() == null)
+                if (getActivity() == null) {
                     return;
+                }
                 dialog_wrong_credentials(result.getMessage(), false);
             }
 
@@ -1318,9 +1372,8 @@ public class SearchResultDetailFragment extends Fragment implements Toolbar.OnMe
     }
 
     /**
-     * A callback interface that all activities containing this fragment must
-     * implement. This mechanism allows activities to be notified of item
-     * selections.
+     * A callback interface that all activities containing this fragment must implement. This
+     * mechanism allows activities to be notified of item selections.
      */
     public interface Callbacks {
         /**
@@ -1344,7 +1397,7 @@ public class SearchResultDetailFragment extends Fragment implements Toolbar.OnMe
                     try {
                         float density = getActivity().getResources().getDisplayMetrics().density;
                         newurl = new URL(ISBNTools.getBestSizeCoverUrl(res.getCover(),
-                                view.getWidth(), (int) (260*density)));
+                                view.getWidth(), (int) (260 * density)));
                         Bitmap mIcon_val = BitmapFactory.decodeStream(newurl
                                 .openConnection().getInputStream());
                         if (mIcon_val.getHeight() > 1
@@ -1381,8 +1434,9 @@ public class SearchResultDetailFragment extends Fragment implements Toolbar.OnMe
         @Override
         @SuppressLint("NewApi")
         protected void onPostExecute(DetailledItem result) {
-            if (getActivity() == null)
+            if (getActivity() == null) {
                 return;
+            }
 
             if (!success || result == null) {
                 showConnectivityError();
@@ -1395,8 +1449,9 @@ public class SearchResultDetailFragment extends Fragment implements Toolbar.OnMe
 
             if (getActivity().getIntent().hasExtra("reservation")
                     && getActivity().getIntent().getBooleanExtra("reservation",
-                    false))
+                    false)) {
                 reservationStart();
+            }
         }
     }
 
@@ -1429,8 +1484,9 @@ public class SearchResultDetailFragment extends Fragment implements Toolbar.OnMe
 
                 if (getActivity().getIntent().hasExtra("reservation")
                         && getActivity().getIntent().getBooleanExtra(
-                        "reservation", false))
+                        "reservation", false)) {
                     app.getApi().start();
+                }
 
                 DetailledItem res = app.getApi().getResultById(a, homebranch);
                 if (res.getId() == null) {
@@ -1440,7 +1496,7 @@ public class SearchResultDetailFragment extends Fragment implements Toolbar.OnMe
                 try {
                     float density = getActivity().getResources().getDisplayMetrics().density;
                     newurl = new URL(ISBNTools.getBestSizeCoverUrl(res.getCover(),
-                            view.getWidth(), (int) (260*density)));
+                            view.getWidth(), (int) (260 * density)));
                     Bitmap mIcon_val = BitmapFactory.decodeStream(newurl
                             .openConnection().getInputStream());
                     if (mIcon_val.getHeight() > 1
@@ -1503,22 +1559,23 @@ public class SearchResultDetailFragment extends Fragment implements Toolbar.OnMe
 
         @Override
         protected void onPostExecute(ReservationResult res) {
-            if (getActivity() == null)
+            if (getActivity() == null) {
                 return;
+            }
 
             if (res == null) {
                 AlertDialog.Builder builder = new AlertDialog.Builder(
                         getActivity());
                 builder.setMessage(R.string.error)
-                        .setCancelable(true)
-                        .setNegativeButton(R.string.close,
-                                new DialogInterface.OnClickListener() {
-                                    @Override
-                                    public void onClick(DialogInterface dialog,
-                                                        int id) {
-                                        dialog.cancel();
-                                    }
-                                });
+                       .setCancelable(true)
+                       .setNegativeButton(R.string.close,
+                               new DialogInterface.OnClickListener() {
+                                   @Override
+                                   public void onClick(DialogInterface dialog,
+                                                       int id) {
+                                       dialog.cancel();
+                                   }
+                               });
                 AlertDialog alert = builder.create();
                 alert.show();
                 return;
@@ -1557,22 +1614,23 @@ public class SearchResultDetailFragment extends Fragment implements Toolbar.OnMe
 
         @Override
         protected void onPostExecute(BookingResult res) {
-            if (getActivity() == null)
+            if (getActivity() == null) {
                 return;
+            }
 
             if (res == null) {
                 AlertDialog.Builder builder = new AlertDialog.Builder(
                         getActivity());
                 builder.setMessage(R.string.error)
-                        .setCancelable(true)
-                        .setNegativeButton(R.string.close,
-                                new DialogInterface.OnClickListener() {
-                                    @Override
-                                    public void onClick(DialogInterface dialog,
-                                                        int id) {
-                                        dialog.cancel();
-                                    }
-                                });
+                       .setCancelable(true)
+                       .setNegativeButton(R.string.close,
+                               new DialogInterface.OnClickListener() {
+                                   @Override
+                                   public void onClick(DialogInterface dialog,
+                                                       int id) {
+                                       dialog.cancel();
+                                   }
+                               });
                 AlertDialog alert = builder.create();
                 alert.show();
                 return;
@@ -1597,9 +1655,10 @@ public class SearchResultDetailFragment extends Fragment implements Toolbar.OnMe
                                     + app.getAccount().getId(), null);
                     app.getApi().getResultById(id, homebranch);
                     return 0;
-                } else
+                } else {
                     ACRA.getErrorReporter().handleException(
                             new Throwable("No ID supplied"));
+                }
             } catch (java.net.SocketException e) {
                 e.printStackTrace();
             } catch (InterruptedIOException e) {
@@ -1614,8 +1673,9 @@ public class SearchResultDetailFragment extends Fragment implements Toolbar.OnMe
 
         @Override
         protected void onPostExecute(Integer result) {
-            if (getActivity() == null)
+            if (getActivity() == null) {
                 return;
+            }
             if (reservation) {
                 reservationDo();
             }

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/SearchResultListActivity.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/SearchResultListActivity.java
@@ -29,28 +29,24 @@ import de.geeksfactory.opacclient.objects.SearchRequestResult;
 import de.geeksfactory.opacclient.objects.SearchResult;
 
 /**
- * An activity representing a list of SearchResults. This activity has different
- * presentations for handset and tablet-size devices. On handsets, the activity
- * presents a list of items, which when touched, lead to a
- * {@link SearchResultDetailActivity} representing item details. On tablets, the
- * activity presents the list of items and item details side-by-side using two
- * vertical panes.
+ * An activity representing a list of SearchResults. This activity has different presentations for
+ * handset and tablet-size devices. On handsets, the activity presents a list of items, which when
+ * touched, lead to a {@link SearchResultDetailActivity} representing item details. On tablets, the
+ * activity presents the list of items and item details side-by-side using two vertical panes.
  * <p/>
- * The activity makes heavy use of fragments. The list of items is a
- * {@link SearchResultListFragment} and the item details (if present) is a
- * {@link SearchResultDetailFragment}.
+ * The activity makes heavy use of fragments. The list of items is a {@link
+ * SearchResultListFragment} and the item details (if present) is a {@link
+ * SearchResultDetailFragment}.
  * <p/>
- * This activity also implements the required
- * {@link SearchResultListFragment.Callbacks} interface to listen for item
- * selections.
+ * This activity also implements the required {@link SearchResultListFragment.Callbacks} interface
+ * to listen for item selections.
  */
 public class SearchResultListActivity extends OpacActivity implements
         SearchResultListFragment.Callbacks,
         SearchResultDetailFragment.Callbacks {
 
     /**
-     * Whether or not the activity is in two-pane mode, i.e. running on a tablet
-     * device.
+     * Whether or not the activity is in two-pane mode, i.e. running on a tablet device.
      */
     protected boolean mTwoPane;
 
@@ -66,8 +62,9 @@ public class SearchResultListActivity extends OpacActivity implements
         // Show the Up button in the action bar.
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
-        if (savedInstanceState == null)
+        if (savedInstanceState == null) {
             setup();
+        }
 
         if (findViewById(R.id.searchresult_detail_container) != null) {
             // The detail container view will be present only in the
@@ -93,8 +90,8 @@ public class SearchResultListActivity extends OpacActivity implements
                     .getBundleExtra("query"));
         }
         getSupportFragmentManager().beginTransaction()
-                .replace(R.id.searchresult_list_container, listFragment)
-                .commit();
+                                   .replace(R.id.searchresult_list_container, listFragment)
+                                   .commit();
     }
 
     @Override
@@ -115,8 +112,8 @@ public class SearchResultListActivity extends OpacActivity implements
     }
 
     /**
-     * Callback method from {@link SearchResultListFragment.Callbacks}
-     * indicating that the item with the given ID was selected.
+     * Callback method from {@link SearchResultListFragment.Callbacks} indicating that the item with
+     * the given ID was selected.
      */
     @Override
     public void onItemSelected(SearchResult result, View coverView) {
@@ -135,11 +132,13 @@ public class SearchResultListActivity extends OpacActivity implements
             // fragment transaction.
             Bundle arguments = new Bundle();
             arguments.putInt(SearchResultDetailFragment.ARG_ITEM_NR, res.getNr());
-            if (res.getId() != null)
+            if (res.getId() != null) {
                 arguments.putString(SearchResultDetailFragment.ARG_ITEM_ID, res.getId());
-            if (res.getCoverBitmap() != null)
+            }
+            if (res.getCoverBitmap() != null) {
                 arguments.putParcelable(SearchResultDetailFragment.ARG_ITEM_COVER_BITMAP,
                         (Parcelable) res.getCoverBitmap());
+            }
             detailFragment = new SearchResultDetailFragment();
             detailFragment.setArguments(arguments);
             getSupportFragmentManager()
@@ -153,16 +152,18 @@ public class SearchResultListActivity extends OpacActivity implements
             Intent detailIntent = new Intent(this,
                     SearchResultDetailActivity.class);
             detailIntent.putExtra(SearchResultDetailFragment.ARG_ITEM_NR, res.getNr());
-            if (res.getId() != null)
+            if (res.getId() != null) {
                 detailIntent.putExtra(SearchResultDetailFragment.ARG_ITEM_ID,
                         res.getId());
+            }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 Explode explode = new Explode();
                 explode.excludeTarget(android.R.id.statusBarBackground, true);
                 getWindow().setExitTransition(explode);
             }
             if (res.getCoverBitmap() != null) {
-                detailIntent.putExtra(SearchResultDetailFragment.ARG_ITEM_COVER_BITMAP, (Parcelable) res.getCoverBitmap());
+                detailIntent.putExtra(SearchResultDetailFragment.ARG_ITEM_COVER_BITMAP,
+                        (Parcelable) res.getCoverBitmap());
                 ActivityOptionsCompat options = ActivityOptionsCompat.makeSceneTransitionAnimation(
                         this,
                         new Pair<View, String>(coverView, getString(R.string.transition_cover)),
@@ -182,7 +183,7 @@ public class SearchResultListActivity extends OpacActivity implements
     @Override
     public void removeFragment() {
         getSupportFragmentManager().beginTransaction().remove(detailFragment)
-                .commit();
+                                   .commit();
     }
 
     @Override

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/SearchResultListFragment.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/SearchResultListFragment.java
@@ -52,19 +52,17 @@ import de.geeksfactory.opacclient.storage.JsonSearchFieldDataSource;
 import de.geeksfactory.opacclient.storage.SearchFieldDataSource;
 
 /**
- * A list fragment representing a list of SearchResults. This fragment also
- * supports tablet devices by allowing list items to be given an 'activated'
- * state upon selection. This helps indicate which item is currently being
- * viewed in a {@link SearchResultDetailFragment}.
+ * A list fragment representing a list of SearchResults. This fragment also supports tablet devices
+ * by allowing list items to be given an 'activated' state upon selection. This helps indicate which
+ * item is currently being viewed in a {@link SearchResultDetailFragment}.
  * <p/>
- * Activities containing this fragment MUST implement the {@link Callbacks}
- * interface.
+ * Activities containing this fragment MUST implement the {@link Callbacks} interface.
  */
 public class SearchResultListFragment extends CustomListFragment {
 
     /**
-     * The serialization (saved instance state) Bundle key representing the
-     * activated item position. Only used on tablets.
+     * The serialization (saved instance state) Bundle key representing the activated item position.
+     * Only used on tablets.
      */
     protected static final String STATE_ACTIVATED_POSITION = "activated_position";
 
@@ -72,8 +70,8 @@ public class SearchResultListFragment extends CustomListFragment {
     protected static final String ARG_VOLUME_QUERY = "volumeQuery";
     protected static final String ARG_GOOGLE_QUERY = "googleQuery";
     /**
-     * A dummy implementation of the {@link Callbacks} interface that does
-     * nothing. Used only when this fragment is not attached to an activity.
+     * A dummy implementation of the {@link Callbacks} interface that does nothing. Used only when
+     * this fragment is not attached to an activity.
      */
     private static Callbacks sDummyCallbacks = new Callbacks() {
         @Override
@@ -85,8 +83,7 @@ public class SearchResultListFragment extends CustomListFragment {
         }
     };
     /**
-     * The fragment's current callback object, which is notified of list item
-     * clicks.
+     * The fragment's current callback object, which is notified of list item clicks.
      */
     protected Callbacks mCallbacks = sDummyCallbacks;
     public ResultsAdapterEndless adapter;
@@ -102,8 +99,8 @@ public class SearchResultListFragment extends CustomListFragment {
     protected FrameLayout errorView;
 
     /**
-     * Mandatory empty constructor for the fragment manager to instantiate the
-     * fragment (e.g. upon screen orientation changes).
+     * Mandatory empty constructor for the fragment manager to instantiate the fragment (e.g. upon
+     * screen orientation changes).
      */
     public SearchResultListFragment() {
     }
@@ -172,12 +169,12 @@ public class SearchResultListFragment extends CustomListFragment {
         final List<Account> accounts = data.getAllAccounts();
         data.close();
 
-        if (accounts.size() == 0)
+        if (accounts.size() == 0) {
             Toast.makeText(getActivity(), R.string.welcome_select,
                     Toast.LENGTH_LONG).show();
-        else if (accounts.size() == 1)
+        } else if (accounts.size() == 1) {
             startGoogleSearch(accounts.get(0), query);
-        else
+        } else {
             new AlertDialog.Builder(getActivity())
                     .setTitle(R.string.account_select)
                     .setAdapter(
@@ -192,6 +189,7 @@ public class SearchResultListFragment extends CustomListFragment {
                                             query);
                                 }
                             }).create().show();
+        }
     }
 
     private void startGoogleSearch(Account account, String query) {
@@ -215,10 +213,11 @@ public class SearchResultListFragment extends CustomListFragment {
         if (savedInstanceState == null && searchresult == null) {
             performsearch();
         } else if (searchresult != null) {
-            if (searchresult.getTotal_result_count() >= 0)
+            if (searchresult.getTotal_result_count() >= 0) {
                 ((ActionBarActivity) getActivity()).getSupportActionBar().setSubtitle(
                         getString(R.string.result_number,
                                 searchresult.getTotal_result_count()));
+            }
         }
     }
 
@@ -253,7 +252,8 @@ public class SearchResultListFragment extends CustomListFragment {
 
         // Notify the active callbacks interface (the activity, if the
         // fragment is attached to one) that an item has been selected.
-        mCallbacks.onItemSelected(searchresult.getResults().get(position), view.findViewById(R.id.ivType));
+        mCallbacks.onItemSelected(searchresult.getResults().get(position),
+                view.findViewById(R.id.ivType));
 
     }
 
@@ -267,8 +267,8 @@ public class SearchResultListFragment extends CustomListFragment {
     }
 
     /**
-     * Turns on activate-on-click mode. When this mode is on, list items will be
-     * given the 'activated' state when touched.
+     * Turns on activate-on-click mode. When this mode is on, list items will be given the
+     * 'activated' state when touched.
      */
     public void setActivateOnItemClick(boolean activateOnItemClick) {
         // When setting CHOICE_MODE_SINGLE, ListView will automatically
@@ -292,10 +292,11 @@ public class SearchResultListFragment extends CustomListFragment {
         for (SearchResult result : searchresult.getResults()) {
             result.setPage(searchresult.getPage_index());
         }
-        if (searchresult.getTotal_result_count() >= 0)
+        if (searchresult.getTotal_result_count() >= 0) {
             ((ActionBarActivity) getActivity()).getSupportActionBar().setSubtitle(
                     getString(R.string.result_number,
                             searchresult.getTotal_result_count()));
+        }
 
         if (searchresult.getResults().size() == 0
                 && searchresult.getTotal_result_count() == 0) {
@@ -335,15 +336,17 @@ public class SearchResultListFragment extends CustomListFragment {
                     @Override
                     public void updateResultCount(int resultCount) {
                         /*
-						 * When IOpac finds more than 200 results, the real
+                         * When IOpac finds more than 200 results, the real
 						 * result count is not known until the second page is
 						 * loaded
 						 */
                         if (resultCount >= 0 && getActivity() != null)
 
+                        {
                             ((ActionBarActivity) getActivity()).getSupportActionBar().setSubtitle(
                                     getString(R.string.result_number,
                                             resultCount));
+                        }
                     }
                 });
         setListAdapter(adapter);
@@ -356,8 +359,9 @@ public class SearchResultListFragment extends CustomListFragment {
     }
 
     public void showConnectivityError(String description) {
-        if (getView() == null || getActivity() == null)
+        if (getView() == null || getActivity() == null) {
             return;
+        }
         errorView.removeAllViews();
         View connError = getActivity().getLayoutInflater().inflate(
                 R.layout.error_connectivity, errorView);
@@ -405,9 +409,8 @@ public class SearchResultListFragment extends CustomListFragment {
     }
 
     /**
-     * A callback interface that all activities containing this fragment must
-     * implement. This mechanism allows activities to be notified of item
-     * selections.
+     * A callback interface that all activities containing this fragment must implement. This
+     * mechanism allows activities to be notified of item selections.
      */
     public interface Callbacks {
         /**
@@ -424,8 +427,9 @@ public class SearchResultListFragment extends CustomListFragment {
         @Override
         protected SearchRequestResult doInBackground(Object... arg0) {
             super.doInBackground(arg0);
-            if (arg0[1] == null)
+            if (arg0[1] == null) {
                 return null;
+            }
             if (arg0[1] instanceof Map<?, ?>) {
                 Map<String, String> query = (Map<String, String>) arg0[1];
                 try {
@@ -496,15 +500,18 @@ public class SearchResultListFragment extends CustomListFragment {
 
                     showConnectivityError(exception.getMessage());
                 } else if (exception instanceof SSLSecurityException) {
-                    if (getActivity() != null)
+                    if (getActivity() != null) {
                         showConnectivityError(getResources().getString(
                                 R.string.connection_error_detail_security));
+                    }
                 } else if (exception instanceof NotReachableException) {
-                    if (getActivity() != null)
+                    if (getActivity() != null) {
                         showConnectivityError(getResources().getString(
                                 R.string.connection_error_detail_nre));
-                } else
+                    }
+                } else {
                     showConnectivityError();
+                }
             } else {
                 loaded(result);
             }
@@ -526,11 +533,13 @@ public class SearchResultListFragment extends CustomListFragment {
             } else {
                 try {
                     List<SearchField> fields = app.getApi().getSearchFields();
-                    if (getActivity() == null)
+                    if (getActivity() == null) {
                         return null;
-                    if (fields.size() == 0)
+                    }
+                    if (fields.size() == 0) {
                         throw new OpacErrorException(
                                 getString(R.string.no_fields_found));
+                    }
                     if (app.getApi().shouldUseMeaningDetector()) {
                         MeaningDetector md = new AndroidMeaningDetector(
                                 getActivity(), app.getLibrary());
@@ -556,19 +565,22 @@ public class SearchResultListFragment extends CustomListFragment {
         }
 
         protected void onPostExecute(List<SearchField> result) {
-            if (getActivity() == null)
+            if (getActivity() == null) {
                 return;
+            }
             if (exception != null) {
-                if (exception instanceof OpacErrorException)
+                if (exception instanceof OpacErrorException) {
                     showConnectivityError(exception.getMessage());
-                else
+                } else {
                     showConnectivityError();
+                }
                 return;
             }
             SearchField fieldToUse = findSearchFieldByMeaning(result,
                     Meaning.FREE);
-            if (fieldToUse == null)
+            if (fieldToUse == null) {
                 fieldToUse = findSearchFieldByMeaning(result, Meaning.TITLE);
+            }
             if (fieldToUse == null) {
                 showConnectivityError(getString(R.string.no_fields_found));
                 return;
@@ -582,8 +594,9 @@ public class SearchResultListFragment extends CustomListFragment {
         private SearchField findSearchFieldByMeaning(List<SearchField> fields,
                                                      Meaning meaning) {
             for (SearchField field : fields) {
-                if (field.getMeaning() == meaning)
+                if (field.getMeaning() == meaning) {
                     return field;
+                }
             }
             return null;
         }

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/StarredFragment.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/StarredFragment.java
@@ -91,7 +91,7 @@ public class StarredFragment extends Fragment implements
             public void onItemClick(AdapterView<?> parent, View view,
                                     int position, long id) {
                 Starred item = (Starred) view.findViewById(R.id.ivDelete)
-                        .getTag();
+                                             .getTag();
                 if (item.getMNr() == null || item.getMNr().equals("null")
                         || item.getMNr().equals("")) {
 
@@ -114,12 +114,13 @@ public class StarredFragment extends Fragment implements
                                         null)));
                             }
                         }
-                        if (title_field != null)
+                        if (title_field != null) {
                             query.add(new SearchQuery(title_field, item
                                     .getTitle()));
-                        else if (free_field != null)
+                        } else if (free_field != null) {
                             query.add(new SearchQuery(free_field, item
                                     .getTitle()));
+                        }
                         app.startSearch(getActivity(), query);
                     } else {
                         Toast.makeText(getActivity(), R.string.no_search_cache,
@@ -135,7 +136,7 @@ public class StarredFragment extends Fragment implements
         listView.setTextFilterEnabled(true);
 
         getActivity().getSupportLoaderManager()
-                .initLoader(0, null, this);
+                     .initLoader(0, null, this);
         listView.setAdapter(adapter);
 
         // Restore the previously serialized activated item position.
@@ -178,22 +179,24 @@ public class StarredFragment extends Fragment implements
 
     @Override
     public Loader<Cursor> onCreateLoader(int arg0, Bundle arg1) {
-        if (app.getLibrary() != null)
+        if (app.getLibrary() != null) {
             return new CursorLoader(getActivity(),
                     app.getStarProviderStarUri(), StarDatabase.COLUMNS,
                     StarDatabase.STAR_WHERE_LIB, new String[]{app
                     .getLibrary().getIdent()}, null);
-        else
+        } else {
             return null;
+        }
     }
 
     @Override
     public void onLoadFinished(Loader<Cursor> loader, Cursor cursor) {
         adapter.swapCursor(cursor);
-        if (cursor.getCount() == 0)
+        if (cursor.getCount() == 0) {
             view.findViewById(R.id.tvWelcome).setVisibility(View.VISIBLE);
-        else
+        } else {
             view.findViewById(R.id.tvWelcome).setVisibility(View.GONE);
+        }
     }
 
     @Override
@@ -245,8 +248,8 @@ public class StarredFragment extends Fragment implements
     }
 
     /**
-     * Turns on activate-on-click mode. When this mode is on, list items will be
-     * given the 'activated' state when touched.
+     * Turns on activate-on-click mode. When this mode is on, list items will be given the
+     * 'activated' state when touched.
      */
     private void setActivateOnItemClick(boolean activateOnItemClick) {
         // When setting CHOICE_MODE_SINGLE, ListView will automatically
@@ -292,10 +295,11 @@ public class StarredFragment extends Fragment implements
             Starred item = StarDataSource.cursorToItem(cursor);
 
             TextView tv = (TextView) view.findViewById(R.id.tvTitle);
-            if (item.getTitle() != null)
+            if (item.getTitle() != null) {
                 tv.setText(Html.fromHtml(item.getTitle()));
-            else
+            } else {
                 tv.setText("");
+            }
 
             ImageView iv = (ImageView) view.findViewById(R.id.ivDelete);
             iv.setFocusableInTouchMode(false);

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/SuggestLibraryActivity.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/SuggestLibraryActivity.java
@@ -159,8 +159,9 @@ public class SuggestLibraryActivity extends ActionBarActivity {
         outState.putCharSequence("city", etCity.getText());
         outState.putCharSequence("name", etName.getText());
         outState.putCharSequence("comment", etComment.getText());
-        if (selectedCity instanceof Serializable)
+        if (selectedCity instanceof Serializable) {
             outState.putSerializable("selectedCity", selectedCity);
+        }
     }
 
     @Override
@@ -236,9 +237,9 @@ public class SuggestLibraryActivity extends ActionBarActivity {
                         }
                     }
                     city.lat = result.getJSONObject("geometry")
-                            .getJSONObject("location").getDouble("lat");
+                                     .getJSONObject("location").getDouble("lat");
                     city.lon = result.getJSONObject("geometry")
-                            .getJSONObject("location").getDouble("lng");
+                                     .getJSONObject("location").getDouble("lng");
                     resultList.add(city);
                 }
             }
@@ -254,8 +255,9 @@ public class SuggestLibraryActivity extends ActionBarActivity {
         int i = 0;
         try {
             while (!found && i < array.length()) {
-                if (array.getString(i).equals(string))
+                if (array.getString(i).equals(string)) {
                     found = true;
+                }
                 i++;
             }
             return found;

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/networking/AdditionalKeyStoresSSLSocketFactory.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/networking/AdditionalKeyStoresSSLSocketFactory.java
@@ -30,8 +30,7 @@ import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
 
 /**
- * Allows you to trust certificates from additional KeyStores in addition to the
- * default KeyStore
+ * Allows you to trust certificates from additional KeyStores in addition to the default KeyStore
  */
 public class AdditionalKeyStoresSSLSocketFactory extends SSLSocketFactory {
     protected SSLContext sslContext = SSLContext.getInstance("TLS");
@@ -63,6 +62,7 @@ public class AdditionalKeyStoresSSLSocketFactory extends SSLSocketFactory {
         private X509TrustManager defaultTrustManager;
         private X509TrustManager localTrustManager;
         private X509Certificate[] acceptedIssuers;
+
         public AdditionalKeyStoresTrustManager(KeyStore localKeyStore) {
             try {
                 TrustManagerFactory tmf = TrustManagerFactory

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/networking/HTTPClient.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/networking/HTTPClient.java
@@ -80,7 +80,8 @@ public class HTTPClient {
                     trustStore = KeyStore.getInstance("BKS");
 
                     final InputStream in = OpacClient.context.getResources()
-                            .openRawResource(R.raw.ssl_trust_store);
+                                                             .openRawResource(
+                                                                     R.raw.ssl_trust_store);
                     try {
                         trustStore.load(in,
                                 "ro5eivoijeeGohsh0daequoo5Zeepaen".toCharArray());

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/reminder/ReminderCheckService.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/reminder/ReminderCheckService.java
@@ -76,7 +76,8 @@ public class ReminderCheckService extends Service {
             am.set(AlarmManager.RTC_WAKEUP, System.currentTimeMillis()
                     + (1000 * 3600 * 24), sender);
 
-            NotificationManager mNotificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+            NotificationManager mNotificationManager =
+                    (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
             mNotificationManager.cancel(OpacClient.NOTIF_ID);
         } else {
             SharedPreferences sp = PreferenceManager
@@ -85,7 +86,8 @@ public class ReminderCheckService extends Service {
             long waittime = (1000 * 3600 * 5);
             boolean executed = false;
 
-            ConnectivityManager connMgr = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
+            ConnectivityManager connMgr =
+                    (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
             NetworkInfo networkInfo = connMgr.getActiveNetworkInfo();
             if (networkInfo != null) {
                 if (sp.getBoolean("notification_service_wifionly", false) == false
@@ -113,8 +115,9 @@ public class ReminderCheckService extends Service {
             am.set(AlarmManager.RTC_WAKEUP, System.currentTimeMillis() + waittime,
                     sender);
 
-            if (!executed)
+            if (!executed) {
                 stopSelf();
+            }
         }
 
         return START_NOT_STICKY;
@@ -135,8 +138,9 @@ public class ReminderCheckService extends Service {
                     ReminderCheckService.this);
             data.open();
             List<Account> accounts = data.getAccountsWithPassword();
-            if (accounts.size() == 0)
+            if (accounts.size() == 0) {
                 return null;
+            }
 
             Log.i("ReminderCheckService",
                     "Opac App Service: ReminderCheckService started");
@@ -163,13 +167,15 @@ public class ReminderCheckService extends Service {
                     Library library = app.getLibrary(account.getLibrary());
                     OpacApi api = app.getNewApi(library);
 
-                    if (!api.isAccountSupported(library))
+                    if (!api.isAccountSupported(library)) {
                         continue;
+                    }
 
                     AccountData res = api.account(account);
 
-                    if (res == null)
+                    if (res == null) {
                         continue;
+                    }
 
                     data.storeCachedAccountData(account, res);
 
@@ -180,8 +186,9 @@ public class ReminderCheckService extends Service {
                             // Don't remember people of bringing back ebooks,
                             // because ... uhm...
                             if (item.get(AccountData.KEY_LENT_DOWNLOAD)
-                                    .startsWith("http"))
+                                    .startsWith("http")) {
                                 continue;
+                            }
                         }
                         if (item.containsKey(AccountData.KEY_LENT_DEADLINE_TIMESTAMP)) {
                             long expiring = Long
@@ -206,8 +213,9 @@ public class ReminderCheckService extends Service {
 
                     if (this_account > 0) {
                         affected_accounts++;
-                        if (first_affected_account == 0)
+                        if (first_affected_account == 0) {
                             first_affected_account = account.getId();
+                        }
                     }
 
                 } catch (SocketException e) {
@@ -244,8 +252,9 @@ public class ReminderCheckService extends Service {
                 // Try again in one hour
                 am.set(AlarmManager.RTC_WAKEUP, System.currentTimeMillis()
                         + (1000 * 3600), sender);
-                if (result == null)
+                if (result == null) {
                     return;
+                }
             }
 
             long expired_new = (Long) result[0];
@@ -255,15 +264,17 @@ public class ReminderCheckService extends Service {
             long affected_accounts = (Long) result[4];
             long first_affected_account = (Long) result[5];
 
-            if (expired_new == 0)
+            if (expired_new == 0) {
                 return;
+            }
 
             SharedPreferences sp = PreferenceManager
                     .getDefaultSharedPreferences(ReminderCheckService.this);
             notification_on = sp.getBoolean("notification_service", false);
 
             if (notification_on) {
-                NotificationManager mNotificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+                NotificationManager mNotificationManager =
+                        (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
 
                 NotificationCompat.Builder nb = new NotificationCompat.Builder(
                         ReminderCheckService.this);
@@ -278,10 +289,13 @@ public class ReminderCheckService extends Service {
                 nb.setNumber((int) expired_new);
                 nb.setSound(null);
 
-                Intent snoozeIntent = new Intent(ReminderCheckService.this, ReminderCheckService.class);
+                Intent snoozeIntent =
+                        new Intent(ReminderCheckService.this, ReminderCheckService.class);
                 snoozeIntent.setAction(ACTION_SNOOZE);
-                PendingIntent piSnooze = PendingIntent.getService(ReminderCheckService.this, 0, snoozeIntent, 0);
-                nb.addAction(R.drawable.ic_action_alarms, getResources().getText(R.string.snooze), piSnooze);
+                PendingIntent piSnooze =
+                        PendingIntent.getService(ReminderCheckService.this, 0, snoozeIntent, 0);
+                nb.addAction(R.drawable.ic_action_alarms, getResources().getText(R.string.snooze),
+                        piSnooze);
 
                 Intent notificationIntent = new Intent(
                         ReminderCheckService.this,

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/searchfields/AndroidMeaningDetector.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/searchfields/AndroidMeaningDetector.java
@@ -32,11 +32,17 @@ public class AndroidMeaningDetector implements MeaningDetector {
         assets = context.getAssets();
         List<String> files = Arrays.asList(assets.list(ASSETS_FIELDSDIR));
         if (files.contains("general.json")) // General
+        {
             readFile("general.json");
+        }
         if (files.contains(lib.getApi() + ".json")) // Api specific
+        {
             readFile(lib.getApi() + ".json");
+        }
         if (files.contains(lib.getIdent() + ".json")) // Library specific
+        {
             readFile(lib.getIdent() + ".json");
+        }
     }
 
     private void readFile(String name) throws IOException, JSONException {
@@ -56,20 +62,23 @@ public class AndroidMeaningDetector implements MeaningDetector {
         // Detect layout of the JSON entries. Can be "field name":
         // "meaning" or "meaning": [ "field name", "field name", ... ]
         Iterator<String> iter = json.keys();
-        if (!iter.hasNext())
+        if (!iter.hasNext()) {
             return; // No entries
+        }
 
         String firstKey = iter.next();
         Object firstValue = json.get(firstKey);
         boolean arrayLayout = firstValue instanceof JSONArray;
         if (arrayLayout) {
-            for (int i = 0; i < ((JSONArray) firstValue).length(); i++)
+            for (int i = 0; i < ((JSONArray) firstValue).length(); i++) {
                 meanings.put(((JSONArray) firstValue).getString(i), firstKey);
+            }
             while (iter.hasNext()) {
                 String key = iter.next();
                 JSONArray val = json.getJSONArray(key);
-                for (int i = 0; i < val.length(); i++)
+                for (int i = 0; i < val.length(); i++) {
                     meanings.put(val.getString(i), key);
+                }
             }
         } else {
             meanings.put(firstKey, (String) firstValue);
@@ -83,21 +92,24 @@ public class AndroidMeaningDetector implements MeaningDetector {
 
     @Override
     public SearchField detectMeaning(SearchField field) {
-        if (field.getMeaning() != null)
+        if (field.getMeaning() != null) {
             return field;
+        }
         if (field.getData() != null && field.getData().has("meaning")) {
             try {
                 String meaningData = field.getData().getString("meaning");
                 String meaningName = meanings.get(meaningData);
-                if (meaningName != null)
+                if (meaningName != null) {
                     return processMeaning(field, meaningName);
+                }
             } catch (JSONException e) {
                 e.printStackTrace();
             }
         } else {
             String meaningName = meanings.get(field.getDisplayName());
-            if (meaningName != null)
+            if (meaningName != null) {
                 return processMeaning(field, meaningName);
+            }
         }
         field.setAdvanced(true);
         return field;

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/storage/AccountDataSource.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/storage/AccountDataSource.java
@@ -145,8 +145,9 @@ public class AccountDataSource {
     }
 
     public long notificationSave(long account, long timestamp) {
-        if (notificationIsSent(account, timestamp))
+        if (notificationIsSent(account, timestamp)) {
             return 0;
+        }
         ContentValues values = new ContentValues();
         values.put("account", account);
         values.put("timestamp", timestamp);
@@ -239,7 +240,7 @@ public class AccountDataSource {
         List<Map<String, String>> res = new ArrayList<Map<String, String>>();
         cursor = database.query(AccountDatabase.TABLENAME_RESERVATION,
                 AccountDatabase.COLUMNS_RESERVATIONS.values()
-                        .toArray(new String[]{}), "account = ?",
+                                                    .toArray(new String[]{}), "account = ?",
                 selectionArgs, null, null, null);
         cursor.moveToFirst();
 
@@ -309,8 +310,9 @@ public class AccountDataSource {
     }
 
     public void storeCachedAccountData(Account account, AccountData adata) {
-        if (adata == null)
+        if (adata == null) {
             return;
+        }
 
         long time = System.currentTimeMillis();
         ContentValues update = new ContentValues();

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/storage/AccountDatabase.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/storage/AccountDatabase.java
@@ -41,6 +41,7 @@ public class AccountDatabase extends SQLiteOpenHelper {
     // CHANGE THIS
     public static final Map<String, String> COLUMNS_LENT;
     public static final Map<String, String> COLUMNS_RESERVATIONS;
+
     static {
         Map<String, String> aMap = new HashMap<String, String>();
         aMap.put(AccountData.KEY_LENT_AUTHOR, "author");
@@ -69,6 +70,7 @@ public class AccountDatabase extends SQLiteOpenHelper {
         bMap.put(AccountData.KEY_RESERVATION_ID, "itemid");
         COLUMNS_RESERVATIONS = Collections.unmodifiableMap(bMap);
     }
+
     public static final String TABLENAME_ACCOUNTS = "accounts";
     public static final String TABLENAME_LENT = "accountdata_lent";
     public static final String TABLENAME_RESERVATION = "accountdata_reservations";

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/storage/SearchFieldDataSource.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/storage/SearchFieldDataSource.java
@@ -46,22 +46,20 @@ public interface SearchFieldDataSource {
 
     /**
      * @param libraryId The ID of the library (Library.getIdent())
-     * @return Timecode (like System.currentTimeMillis()) for when the data of
-     * this library was last updated
+     * @return Timecode (like System.currentTimeMillis()) for when the data of this library was last
+     * updated
      */
     public long getLastSearchFieldUpdateTime(String libraryId);
 
     /**
      * @param libraryId The ID of the library (Library.getIdent())
-     * @return Version code of the last app version that updated the search
-     * field for this library
+     * @return Version code of the last app version that updated the search field for this library
      */
     public int getLastSearchFieldUpdateVersion(String libraryId);
 
     /**
      * @param libraryId The ID of the library (Library.getIdent())
-     * @return System language with which the search fields were saved
-     * (ISO-639-1 code)
+     * @return System language with which the search fields were saved (ISO-639-1 code)
      */
     public String getSearchFieldLanguage(String libraryId);
 }

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/storage/StarContentProvider.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/storage/StarContentProvider.java
@@ -118,7 +118,7 @@ public class StarContentProvider extends ContentProvider {
 
     private long insertIntoDatabase(String table, ContentValues values) {
         return database.getWritableDatabase()
-                .insertOrThrow(table, null, values);
+                       .insertOrThrow(table, null, values);
     }
 
     @Override

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/storage/StarDataSource.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/storage/StarDataSource.java
@@ -55,9 +55,9 @@ public class StarDataSource {
         values.put("title", title);
         values.put("bib", bib);
         context.getContentResolver()
-                .insert(((OpacClient) context.getApplication())
-                                .getStarProviderStarUri(),
-                        values);
+               .insert(((OpacClient) context.getApplication())
+                               .getStarProviderStarUri(),
+                       values);
     }
 
     public List<Starred> getAllItems(String bib) {
@@ -142,8 +142,9 @@ public class StarDataSource {
     }
 
     public boolean isStarred(String bib, String id) {
-        if (id == null)
+        if (id == null) {
             return false;
+        }
         String[] selA = {bib, id};
         Cursor cursor = context
                 .getContentResolver()
@@ -157,8 +158,9 @@ public class StarDataSource {
     }
 
     public boolean isStarredTitle(String bib, String title) {
-        if (title == null)
+        if (title == null) {
             return false;
+        }
         String[] selA = {bib, title};
         Cursor cursor = context
                 .getContentResolver()
@@ -174,9 +176,9 @@ public class StarDataSource {
     public void remove(Starred item) {
         String[] selA = {"" + item.getId()};
         context.getContentResolver()
-                .delete(((OpacClient) context.getApplication())
-                                .getStarProviderStarUri(),
-                        StarDatabase.STAR_WHERE_ID, selA);
+               .delete(((OpacClient) context.getApplication())
+                               .getStarProviderStarUri(),
+                       StarDatabase.STAR_WHERE_ID, selA);
     }
 
     public void renameLibraries(Map<String, String> map) {
@@ -185,10 +187,10 @@ public class StarDataSource {
             cv.put("bib", entry.getValue());
 
             context.getContentResolver()
-                    .update(((OpacClient) context.getApplication())
-                                    .getStarProviderStarUri(),
-                            cv, StarDatabase.STAR_WHERE_LIB,
-                            new String[]{entry.getKey()});
+                   .update(((OpacClient) context.getApplication())
+                                   .getStarProviderStarUri(),
+                           cv, StarDatabase.STAR_WHERE_LIB,
+                           new String[]{entry.getKey()});
         }
     }
 }

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/storage/StarDatabase.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/storage/StarDatabase.java
@@ -57,7 +57,9 @@ public class StarDatabase extends SQLiteOpenHelper {
                 + oldVersion + " to " + newVersion
                 + ", which will destroy all old data");
 
-        db.execSQL("create table temp ( id integer primary key autoincrement, medianr text, bib text, title text );");
+        db.execSQL(
+                "create table temp ( id integer primary key autoincrement, medianr text, " +
+                        "bib text, title text );");
         db.execSQL("insert into temp select * from starred;");
         db.execSQL("drop table starred;");
         onCreate(db);

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/ui/ScrimInsetsFrameLayout.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/ui/ScrimInsetsFrameLayout.java
@@ -29,8 +29,8 @@ import de.geeksfactory.opacclient.R;
 
 
 /**
- * A layout that draws something in the insets passed to {@link #fitSystemWindows(Rect)}, i.e. the area above UI chrome
- * (status and navigation bars, overlay action bars).
+ * A layout that draws something in the insets passed to {@link #fitSystemWindows(Rect)}, i.e. the
+ * area above UI chrome (status and navigation bars, overlay action bars).
  */
 public class ScrimInsetsFrameLayout extends FrameLayout {
     private Drawable mInsetForeground;
@@ -128,10 +128,10 @@ public class ScrimInsetsFrameLayout extends FrameLayout {
     }
 
     /**
-     * Allows the calling container to specify a callback for custom processing when insets change (i.e. when
-     * {@link #fitSystemWindows(Rect)} is called. This is useful for setting padding on UI elements based on
-     * UI chrome insets (e.g. a Google Map or a ListView). When using with ListView or GridView, remember to set
-     * clipToPadding to false.
+     * Allows the calling container to specify a callback for custom processing when insets change
+     * (i.e. when {@link #fitSystemWindows(Rect)} is called. This is useful for setting padding on
+     * UI elements based on UI chrome insets (e.g. a Google Map or a ListView). When using with
+     * ListView or GridView, remember to set clipToPadding to false.
      */
     public void setOnInsetsCallback(OnInsetsCallback onInsetsCallback) {
         mOnInsetsCallback = onInsetsCallback;

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/ui/WhitenessUtils.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/ui/WhitenessUtils.java
@@ -20,8 +20,8 @@ import android.graphics.Bitmap;
 import android.graphics.Color;
 
 /**
- * Utility class for determining whether Bitmaps contain a lot of white pixels in locations
- * where QuickContactActivity will want to place white text or buttons.
+ * Utility class for determining whether Bitmaps contain a lot of white pixels in locations where
+ * QuickContactActivity will want to place white text or buttons.
  * <p/>
  * This class liberally considers bitmaps white. All constants are chosen with a small amount of
  * experimentation. Despite a lack of rigour, this class successfully allows QuickContactsActivity
@@ -48,8 +48,8 @@ public class WhitenessUtils {
     private static final float LUMINANCE_OF_WHITE = 0.90f;
 
     /**
-     * Returns true if 20% of the image's top right corner is white, or 20% of the bottom
-     * of the image is white.
+     * Returns true if 20% of the image's top right corner is white, or 20% of the bottom of the
+     * image is white.
      */
     public static boolean isBitmapWhiteAtTopOrBottom(Bitmap largeBitmap) {
         final Bitmap smallBitmap = scaleBitmapDown(largeBitmap);

--- a/opacclient/opacapp/src/main/res/raw-de/privacy.html
+++ b/opacclient/opacapp/src/main/res/raw-de/privacy.html
@@ -1,11 +1,1 @@
-<p>Sämtliche Kommunikation findet direkt zwischen deinem Smartphone und dem Server deiner Bibliothek
-    statt. Wir speichern keine Daten, da wir auch keine zu sehen bekommen. Weder was du suchst, noch
-    deine Ausweisdaten; das alles wird nur auf deinem Gerät gespeichert. Was der Server deiner
-    Bibliothek speichert, wissen wir nicht – das musst du deine Bibliothek fragen.<br><br>Einzige
-    Ausnahme: Wenn du über in der App ein Suchergebnis an Freunde schickst, dann nimmt der Link, auf
-    den dein Freund klickt (wenn dieser die App nicht für die gleiche Stadt installiert hat), einen
-    Umweg über unseren Server. In diesem Fall speichert unser Server, welches Buch aufgerufen wurde
-    zusammen mit dem Zeitpunkt des Aufrufes, aber keine IP-Adressen, Browserdaten oder sonstiges.
-    Das liegt daran, dass diese „Teilen“-Funktion etwas ist, was die meisten Bibliothekssysteme
-    eigentlich gar nicht können, und was wir deswegen über einen kleinen Umweg nachbauen müssen.<br><br>
-</p>
+<p>Sämtliche Kommunikation findet direkt zwischen deinem Smartphone und dem Server deiner Bibliothek statt. Wir speichern keine Daten, da wir auch keine zu sehen bekommen. Weder was du suchst, noch deine Ausweisdaten; das alles wird nur auf deinem Gerät gespeichert. Was der Server deiner Bibliothek speichert, wissen wir nicht – das musst du deine Bibliothek fragen.<br><br>Einzige Ausnahme: Wenn du über in der App ein Suchergebnis an Freunde schickst, dann nimmt der Link, auf den dein Freund klickt (wenn dieser die App nicht für die gleiche Stadt installiert hat), einen Umweg über unseren Server. In diesem Fall speichert unser Server, welches Buch aufgerufen wurde zusammen mit dem Zeitpunkt des Aufrufes, aber keine IP-Adressen, Browserdaten oder sonstiges. Das liegt daran, dass diese „Teilen“-Funktion etwas ist, was die meisten Bibliothekssysteme eigentlich gar nicht können, und was wir deswegen über einen kleinen Umweg nachbauen müssen.<br><br></p>

--- a/opacclient/opacapp/src/main/res/raw-de/thanks.html
+++ b/opacclient/opacapp/src/main/res/raw-de/thanks.html
@@ -1,9 +1,4 @@
 <div>
-    <p><strong>Mitautoren</strong><br>Johan von Forstner<br>Rüdiger Wurth (Integration von
-        BiBer-Bibliotheken)<br><br><strong>Danke</strong><br>an Céline Ah. und weitere für
-        Inspiration und Ideen<br>an die Bibliotheken, die Werbung für die App machen oder Zugang zu
-        Ihren Mitgliederbereichen bereitstellen.<br>an zahllose anonyme und namentliche Einsender
-        von Feedback und Details über Bibliotheken<br></p>
-
-    <p>Thanks to all our translators into other languages.</p>
+<p><strong>Mitautoren</strong><br>Johan von Forstner<br>Rüdiger Wurth (Integration von BiBer-Bibliotheken)<br><br><strong>Danke</strong><br>an Céline Ah. und weitere für Inspiration und Ideen<br>an die Bibliotheken, die Werbung für die App machen oder Zugang zu Ihren Mitgliederbereichen bereitstellen.<br>an zahllose anonyme und namentliche Einsender von Feedback und Details über Bibliotheken<br></p>
+<p>Thanks to all our translators into other languages.</p>
 </div>

--- a/opacclient/opacapp/src/main/res/raw-it/privacy.html
+++ b/opacclient/opacapp/src/main/res/raw-it/privacy.html
@@ -1,12 +1,1 @@
-<p>Tutte le comunicazioni avvengono direttamente tra lo smartphone e il server della biblioteca.
-    Nessun dato viene da noi salvato in quanto nessun dato viene a noi trasmesso. Sia le ricerche
-    effettuate che i dati personali relativi agli account vengono salvati esclusivamente sul tuo
-    smartphone. Cosa viene salvato sui server delle biblioteche non dipende da noi e non siamo in
-    grado neanche di saperlo, per maggiori informazioni rivolgiti direttamente alla biblioteca
-    interessata.<br><br>Unica eccezione: condividendo il risultato di una ricerca direttamente
-    dall'applicazione con un amico/a e nel caso in cui lui/lei non abbia la stessa biblioteca nella
-    sua lista cliccando sul link che gli hai inviato il collegamento avverrà attraverso il nostro
-    server. In questo caso il server salva quale libro è stato visualizzato e l'ora della richiesta
-    però, né l'indirizzo IP né i dati relativi al suo web browser come neanche altre informazioni
-    vengono salvate. Questo è dovuto al fatto che la funzione Condividi spesso non è supportata
-    nativamente dai sistemi delle biblioteche.<br><br></p>
+<p>Tutte le comunicazioni avvengono direttamente tra lo smartphone e il server della biblioteca. Nessun dato viene da noi salvato in quanto nessun dato viene a noi trasmesso. Sia le ricerche effettuate che i dati personali relativi agli account vengono salvati esclusivamente sul tuo smartphone. Cosa viene salvato sui server delle biblioteche non dipende da noi e non siamo in grado neanche di saperlo, per maggiori informazioni rivolgiti direttamente alla biblioteca interessata.<br><br>Unica eccezione: condividendo il risultato di una ricerca direttamente dall'applicazione con un amico/a e nel caso in cui lui/lei non abbia la stessa biblioteca nella sua lista cliccando sul link che gli hai inviato il collegamento avverrà attraverso il nostro server. In questo caso il server salva quale libro è stato visualizzato e l'ora della richiesta però, né l'indirizzo IP né i dati relativi al suo web browser come neanche altre informazioni vengono salvate. Questo è dovuto al fatto che la funzione Condividi spesso non è supportata nativamente dai sistemi delle biblioteche.<br><br></p>

--- a/opacclient/opacapp/src/main/res/raw-it/thanks.html
+++ b/opacclient/opacapp/src/main/res/raw-it/thanks.html
@@ -1,8 +1,4 @@
 <div>
-    <p><strong>Coautori</strong><br>Johan von Forstner<br>Rüdiger Wurth (integrazione con BiBer)<br><br><strong>Grazie</strong><br>a
-        Céline Ah. e altri per l'inspirazione e le idee<br>alle biblioteche che promuovono
-        l'applicazione e rendono possibile l'accesso ai membri all'area riservata.<br>alle persone,
-        anonime e non, che inviano feedback e informazioni relative alle biblioteche.<br></p>
-
-    <p>Traduzione italiana a cura di Matteo Faraone</p>
+<p><strong>Coautori</strong><br>Johan von Forstner<br>Rüdiger Wurth (integrazione con BiBer)<br><br><strong>Grazie</strong><br>a Céline Ah. e altri per l'inspirazione e le idee<br>alle biblioteche che promuovono l'applicazione e rendono possibile l'accesso ai membri all'area riservata.<br>alle persone, anonime e non, che inviano feedback e informazioni relative alle biblioteche.<br></p>
+<p>Traduzione italiana a cura di Matteo Faraone</p>
 </div>

--- a/opacclient/opacapp/src/main/res/raw-tr/privacy.html
+++ b/opacclient/opacapp/src/main/res/raw-tr/privacy.html
@@ -1,10 +1,1 @@
-<p>Tüm iletişim direkt olarak sizin telefonunuz ve kütüphanenizin sunucusu arasında gerçekleşir. Biz
-    hiçbir veriyi saklamayız çünkü onları görmeyiz. Yaptığınız aramalar ve hesap verileriniz – her
-    şey sizin telefonunuza kaydedilir. Kütüphanenizin sunucusunun ne tür verileri sakladığını
-    bilmiyoruz – bu konu hakkında kütüphanenize danışabilirsiniz.<br><br>Tek istisna: Bir arama
-    sonucunu bu uygulama aracılığıyla arkadaşlarınızla paylaştığınızda, bu paylaşılan bağlantıyı
-    arkadaşınız kaydettiğinde bizim sunucumuzda bir tur atar (eğer arkadaşınız bu uygulamayı
-    yüklememiş ve aynı kütüphaneyi ayarlamamışsa). Bu durumda bizim sunucumuz istenen kitabı ve
-    zamanını kaydeder, IP adresi, tarayıcı bilgileri gibi bilgileri kesinlikle kaydetmez. "Paylaşma"
-    özelliği çoğu kütüphanede desteklenmediği için bu durumu böyle bir teknikle düzelmeye ihtiyaç
-    duyduk.<br><br></p>
+<p>Tüm iletişim direkt olarak sizin telefonunuz ve kütüphanenizin sunucusu arasında gerçekleşir. Biz hiçbir veriyi saklamayız çünkü onları görmeyiz. Yaptığınız aramalar ve hesap verileriniz – her şey sizin telefonunuza kaydedilir. Kütüphanenizin sunucusunun ne tür verileri sakladığını bilmiyoruz – bu konu hakkında kütüphanenize danışabilirsiniz.<br><br>Tek istisna: Bir arama sonucunu bu uygulama aracılığıyla arkadaşlarınızla paylaştığınızda, bu paylaşılan bağlantıyı arkadaşınız kaydettiğinde bizim sunucumuzda bir tur atar (eğer arkadaşınız bu uygulamayı yüklememiş ve aynı kütüphaneyi ayarlamamışsa). Bu durumda bizim sunucumuz istenen kitabı ve zamanını kaydeder, IP adresi, tarayıcı bilgileri gibi bilgileri kesinlikle kaydetmez. "Paylaşma" özelliği çoğu kütüphanede desteklenmediği için bu durumu böyle bir teknikle düzelmeye ihtiyaç duyduk.<br><br></p>

--- a/opacclient/opacapp/src/main/res/raw-tr/thanks.html
+++ b/opacclient/opacapp/src/main/res/raw-tr/thanks.html
@@ -1,7 +1,4 @@
 <div>
-    <p><strong>Yardımcılar</strong><br>Johan von Forstner<br>Rüdiger Wurth (BiBer kütüphaneleri)<br><br><strong>Teşekkürler</strong><br>Céline
-        Ah. ilham ve fikirleri için<br>uygulamanın reklamını yapan ve test hesabı açan kütüphanelere<br>kütüphaneler
-        hakkında ayrıntı ve geri bildirim gönderen sayısız kullanıcıya<br></p>
-
-    <p>Thanks to all our translators into other languages.</p>
+<p><strong>Yardımcılar</strong><br>Johan von Forstner<br>Rüdiger Wurth (BiBer kütüphaneleri)<br><br><strong>Teşekkürler</strong><br>Céline Ah. ilham ve fikirleri için<br>uygulamanın reklamını yapan ve test hesabı açan kütüphanelere<br>kütüphaneler hakkında ayrıntı ve geri bildirim gönderen sayısız kullanıcıya<br></p>
+<p>Thanks to all our translators into other languages.</p>
 </div>

--- a/opacclient/opacapp/src/main/res/raw/privacy.html
+++ b/opacclient/opacapp/src/main/res/raw/privacy.html
@@ -1,10 +1,1 @@
-<p>All communication takes place directly between your smartphone and your library's server. We do
-    not save any data because we do not get any to see. Neither your search queries nor your account
-    data – everything is exclusively saved on your device. We do not know what data your library's
-    server saves – you would need to ask your library about that.<br><br>Only exception: When you
-    share a search result from the app to your friends, the link that your friend saves takes a
-    detour through our server (if he does not have the app installed and set-up for the same
-    library). In this case, our server will save the time of the request and which book was
-    requested, but no IP addresses, browser data etc. This is necessary because this "Sharing"
-    feature is something that most library systems do not support natively, so we need to rebuild it
-    using this technique.<br><br></p>
+<p>All communication takes place directly between your smartphone and your library's server. We do not save any data because we do not get any to see. Neither your search queries nor your account data – everything is exclusively saved on your device. We do not know what data your library's server saves – you would need to ask your library about that.<br><br>Only exception: When you share a search result from the app to your friends, the link that your friend saves takes a detour through our server (if he does not have the app installed and set-up for the same library). In this case, our server will save the time of the request and which book was requested, but no IP addresses, browser data etc. This is necessary because this "Sharing" feature is something that most library systems do not support natively, so we need to rebuild it using this technique.<br><br></p>

--- a/opacclient/opacapp/src/main/res/raw/thanks.html
+++ b/opacclient/opacapp/src/main/res/raw/thanks.html
@@ -1,5 +1,2 @@
-<p><strong>Co authors</strong><br>Johan von Forstner<br>Rüdiger Wurth (BiBer
-    libraries)<br><br><strong>Thanks</strong><br>to Céline Ah. for inspiration and ideas<br>to
-    libraries that advertise the app or supply test accounts for their member area.<br>to
-    innumerable anonymous and named senders of feedback and details about libraries<br></p>
+<p><strong>Co authors</strong><br>Johan von Forstner<br>Rüdiger Wurth (BiBer libraries)<br><br><strong>Thanks</strong><br>to Céline Ah. for inspiration and ideas<br>to libraries that advertise the app or supply test accounts for their member area.<br>to innumerable anonymous and named senders of feedback and details about libraries<br></p>
 <p>Thanks to all our translators into other languages.</p>


### PR DESCRIPTION
This fixes the following things from the list in #281:
- Put simple block expressions (if without {…}) on one line with their body (braces are now added when there is a line break)
- Enforce line length of 100 characters

And:
- Remove the line breaks from `thanks.html` and `privacy.html` because they otherwise appear in Transifex (which is probably confusing for translators) and change the corresponding code style setting so that it they won't be added again