### PR TITLE
Remove another method call only working on API >= 17

### DIFF
--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/LibraryListActivity.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/LibraryListActivity.java
@@ -770,7 +770,7 @@ public class LibraryListActivity extends ActionBarActivity {
             libraries = result;
             if (dialog != null) dialog.dismiss();
             if (libraries == null) return;
-            if (LibraryListActivity.this.isDestroyed()) return;
+            if (!visible) return;
 
             // Get the intent, verify the action and get the query
             Intent intent = getIntent();


### PR DESCRIPTION
I still don't understand why Android Studio didn't warn me about this.