### PR TITLE
Fix Bug on Samsung devices with Android 4.2

### DIFF
--- a/opacclient/.idea/inspectionProfiles/Project_Default.xml
+++ b/opacclient/.idea/inspectionProfiles/Project_Default.xml
@@ -10,6 +10,9 @@
       <option name="REPORT_METHODS" value="false" />
       <option name="REPORT_FIELDS" value="true" />
     </inspection_tool>
+    <inspection_tool class="EnumSwitchStatementWhichMissesCases" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoreSwitchStatementsWithDefault" value="false" />
+    </inspection_tool>
     <inspection_tool class="LoggerInitializedWithForeignClass" enabled="false" level="WARNING" enabled_by_default="false">
       <option name="loggerClassName" value="org.apache.log4j.Logger,org.slf4j.LoggerFactory,org.apache.commons.logging.LogFactory,java.util.logging.Logger" />
       <option name="loggerFactoryMethodName" value="getLogger,getLogger,getLog,getLogger" />

--- a/opacclient/opacapp/build.gradle
+++ b/opacclient/opacapp/build.gradle
@@ -29,9 +29,9 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
             signingConfig signingConfigs.release
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
+            proguardFiles 'proguard-rules.txt'
         }
     }
     compileOptions {

--- a/opacclient/opacapp/proguard-rules.txt
+++ b/opacclient/opacapp/proguard-rules.txt
@@ -1,0 +1,12 @@
+-dontoptimize
+-dontobfuscate
+# Rename android.support.v7 classes to fix bug on Samsung (and other) devices running Android 4.2
+# See also: https://code.google.com/p/android/issues/detail?id=78377
+-repackageclasses "android.support.v7"
+-keep class android.support.v7.widget.** { *; }
+-keep interface android.support.v7.widget.** { *; }
+
+# JavaMeaningDetector uses these Java 7 classes for accessing files which are not included in
+# Android, so we need to ignore warnings related to them
+-dontwarn java.nio.file.**
+-dontwarn java.io.File


### PR DESCRIPTION
We need to repackage android.support.v7 classes using ProGuard because some devices include an old version of the support library (normally they shouldn't include the support library at all), which causes a `java.lang.NoClassDefFoundError`.
See also: https://code.google.com/p/android/issues/detail?id=78377