### PR TITLE
Fix crash in AccountFragment

### DIFF
--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/TestApi.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/TestApi.java
@@ -4,6 +4,7 @@ import org.json.JSONException;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -155,7 +156,25 @@ public class TestApi implements OpacApi {
     @Override
     public AccountData account(Account account)
             throws IOException, JSONException, OpacErrorException {
-        return null;
+        AccountData data = new AccountData(account.getId());
+        List<Map<String, String>> lent = new ArrayList<>();
+        List<Map<String, String>> reservations = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            Map<String, String> lentItem = new HashMap<>();
+            lentItem.put(AccountData.KEY_LENT_AUTHOR, "Max Mustermann");
+            lentItem.put(AccountData.KEY_LENT_TITLE, "Lorem Ipsum");
+            lentItem.put(AccountData.KEY_LENT_STATUS, "hier ist der Status");
+            lent.add(lentItem);
+
+            Map<String, String> reservationItem = new HashMap<>();
+            reservationItem.put(AccountData.KEY_RESERVATION_AUTHOR, "Max Mustermann");
+            reservationItem.put(AccountData.KEY_RESERVATION_TITLE, "Lorem Ipsum");
+            reservationItem.put(AccountData.KEY_RESERVATION_READY, "heute");
+            reservations.add(reservationItem);
+        }
+        data.setLent(lent);
+        data.setReservations(reservations);
+        return data;
     }
 
     @Override
@@ -175,7 +194,7 @@ public class TestApi implements OpacApi {
 
     @Override
     public boolean isAccountSupported(Library library) {
-        return false;
+        return true;
     }
 
     @Override

--- a/opacclient/opacapp/src/main/assets/bibs/Test.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Test.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "test",
     "city": "Test",
     "country": "Test",

--- a/opacclient/opacapp/src/main/res/layout-w720dp/fragment_account.xml
+++ b/opacclient/opacapp/src/main/res/layout-w720dp/fragment_account.xml
@@ -28,7 +28,8 @@
         <ScrollView
             android:id="@+id/svAccount"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="wrap_content"
+            android:transitionGroup="true">
 
             <RelativeLayout
                 android:id="@+id/rlAccView"

--- a/opacclient/opacapp/src/main/res/layout/fragment_account.xml
+++ b/opacclient/opacapp/src/main/res/layout/fragment_account.xml
@@ -27,7 +27,8 @@
         <ScrollView
             android:id="@+id/svAccount"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="wrap_content"
+            android:transitionGroup="true">
 
             <RelativeLayout
                 android:id="@+id/rlAccView"


### PR DESCRIPTION
A crash was caused when going from SearchFragment to AccountFragment when the list of lent and reserved items was taller than a certain amount (depending on the device's GPU, typically 4096 pixels). To reproduce the bug, I implemented the `account()` function of the `TestApi` to create a very long list (it needed to be 16384 pixels tall in the emulator).
As we received a number of crash reports (and a negative review in the Play Store) concerning this bug, this could maybe justify a bugfix release.