### PR TITLE
iOPAC improvements

### DIFF
--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/IOpac.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/IOpac.java
@@ -333,17 +333,26 @@ public class IOpac extends BaseApi implements OpacApi {
             // Status
             String status = tr.select("td").get(colmap.get("returndate"))
                               .text().trim().replace("\u00a0", "");
-            if (status.equals("")
-                    || status.toLowerCase(Locale.GERMAN).contains("onleihe")
-                    || status.contains("verleihbar")
-                    || status.contains("entleihbar")
-                    || status.contains("ausleihbar")) {
-                sr.setStatus(Status.GREEN);
-            } else {
+            SimpleDateFormat df = new SimpleDateFormat("dd.MM.yyyy", Locale.GERMAN);
+            try {
+                df.parse(status);
+                // this is a return date
                 sr.setStatus(Status.RED);
                 sr.setInnerhtml(sr.getInnerhtml() + "<br><i>"
                         + stringProvider.getString(StringProvider.LENT_UNTIL)
                         + " " + status + "</i>");
+            } catch (ParseException e) {
+                // this is a different status text
+                String lc = status.toLowerCase(Locale.GERMAN);
+                if ((lc.equals("")
+                        || lc.toLowerCase(Locale.GERMAN).contains("onleihe")
+                        || lc.contains("verleihbar") || lc.contains("entleihbar")
+                        || lc.contains("ausleihbar")) && !lc.contains("nicht")) {
+                    sr.setStatus(Status.GREEN);
+                } else {
+                    sr.setStatus(Status.YELLOW);
+                    sr.setInnerhtml(sr.getInnerhtml() + "<br><i>" + status + "</i>");
+                }
             }
 
             // In some libraries (for example search for "atelier" in Preetz)

--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/IOpac.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/IOpac.java
@@ -665,9 +665,10 @@ public class IOpac extends BaseApi implements OpacApi {
             Element form = doc.select("form[name=form1]").first();
             String sessionid = form.select("input[name=sessionid]").attr(
                     "value");
+            String kndnr = form.select("input[name=kndnr]").attr("value");
             String mednr = form.select("input[name=mednr]").attr("value");
             httpGet(opac_url + "/cgi-bin/di.exe?mode=9&kndnr="
-                    + account.getName() + "&mednr=" + mednr + "&sessionid="
+                    + kndnr + "&mednr=" + mednr + "&sessionid="
                     + sessionid + "&psh100=Stornieren", getDefaultEncoding());
             return new CancelResult(MultiStepResult.Status.OK);
         } catch (Throwable e) {
@@ -836,6 +837,9 @@ public class IOpac extends BaseApi implements OpacApi {
                         String value = cell.select("input.VerlAllCheckboxOK").first().val();
                         e.put(AccountData.KEY_LENT_LINK, "NEW" + value);
                         e.put(AccountData.KEY_LENT_ID, value.split(";")[0]);
+                        if (cell.select("input.VerlAllCheckboxOK").hasAttr("disabled")) {
+                            e.put(AccountData.KEY_LENT_RENEWABLE, "N");
+                        }
                     } else {
                         // previous versions - link for prolonging on every medium
                         String link = cell.select("a").attr("href");


### PR DESCRIPTION
More fixes for iOPAC 1.45:
- non-prolongable media should be recognized properly (not tested)
- support for new sharing URLs that lead to the full frameset of the OPAC, not only the detail page
and for all iOPAC versions
- fix cancelling reservations for when "kndnr" is not equal to the login number (for whatever reason)
- error message when reserving media that is already lent
- improve detecting the status in the result list