### PR TITLE
Account support for 3 more libraries using LBS

### DIFF
--- a/opacclient/opacapp/src/main/assets/bibs/Greifswald_Uni.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Greifswald_Uni.json
@@ -1,11 +1,12 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "pica",
     "city": "Greifswald",
     "country": "Deutschland",
     "data": {
         "baseurl": "https://lhgrw.gbv.de",
-        "db": "1"
+        "db": "1",
+        "account_system": "lbs"
     },
     "geo": [
         54.0915636,

--- a/opacclient/opacapp/src/main/assets/bibs/Stralsund_FH.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Stralsund_FH.json
@@ -1,11 +1,12 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "pica",
     "city": "Stralsund",
     "country": "Deutschland",
     "data": {
         "baseurl": "https://lhgrw.gbv.de",
-        "db": "2"
+        "db": "2",
+        "account_system": "lbs"
     },
     "geo": [
         54.2994048,

--- a/opacclient/opacapp/src/main/assets/bibs/Weimar_Uni.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Weimar_Uni.json
@@ -1,11 +1,12 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "pica",
     "city": "Weimar",
     "country": "Deutschland",
     "data": {
         "baseurl": "https://opac.lbs-weimar.gbv.de",
-        "db": "1"
+        "db": "1",
+        "account_system": "lbs"
     },
     "geo": [
         50.979444,


### PR DESCRIPTION
I found that Greifswald_Uni, Stralsung_FH and Weimar_Uni also use LBS and activated account support for them. This was not tested.