### PR TITLE
WinBiap account support

### DIFF
--- a/opacclient/libopac/build.gradle
+++ b/opacclient/libopac/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     // Use older org.json version to have an environment equivalent to the android platform
     compile 'org.json:json:20090211'
-    compile 'org.jsoup:jsoup:1.8.1'
+    compile 'org.jsoup:jsoup:1.8.3'
     compile 'org.apache.httpcomponents:httpmime:4.3.6'
     compile project(':noandroid')
 }

--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/i18n/DummyStringProvider.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/i18n/DummyStringProvider.java
@@ -21,6 +21,8 @@
  */
 package de.geeksfactory.opacclient.i18n;
 
+import de.geeksfactory.opacclient.objects.SearchResult;
+
 public class DummyStringProvider implements StringProvider {
     @Override
     public String getString(String identifier) {
@@ -49,5 +51,10 @@ public class DummyStringProvider implements StringProvider {
             builder.append(arg.toString());
         }
         return builder.toString();
+    }
+
+    @Override
+    public String getMediaTypeName(SearchResult.MediaType mediaType) {
+        return mediaType.toString();
     }
 }

--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/i18n/StringProvider.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/i18n/StringProvider.java
@@ -36,45 +36,45 @@ package de.geeksfactory.opacclient.i18n;
  * @since 3.2.1
  */
 public interface StringProvider {
-    public static String LIMITED_NUM_OF_CRITERIA = "limited_num_of_criteria";
-    public static String NO_CRITERIA_INPUT = "no_criteria_input";
-    public static String COMBINATION_NOT_SUPPORTED = "combination_not_supported";
-    public static String UNKNOWN_ERROR = "unknown_error";
-    public static String UNKNOWN_ERROR_WITH_DESCRIPTION = "unknown_error_with_description";
-    public static String UNKNOWN_ERROR_ACCOUNT = "unknown_error_account";
-    public static String UNKNOWN_ERROR_ACCOUNT_WITH_DESCRIPTION =
+    String LIMITED_NUM_OF_CRITERIA = "limited_num_of_criteria";
+    String NO_CRITERIA_INPUT = "no_criteria_input";
+    String COMBINATION_NOT_SUPPORTED = "combination_not_supported";
+    String UNKNOWN_ERROR = "unknown_error";
+    String UNKNOWN_ERROR_WITH_DESCRIPTION = "unknown_error_with_description";
+    String UNKNOWN_ERROR_ACCOUNT = "unknown_error_account";
+    String UNKNOWN_ERROR_ACCOUNT_WITH_DESCRIPTION =
             "unknown_error_account_with_description";
-    public static String INTERNAL_ERROR = "internal_error";
-    public static String INTERNAL_ERROR_WITH_DESCRIPTION = "internal_error_with_description";
-    public static String LOGIN_FAILED = "login_failed";
-    public static String COULD_NOT_LOAD_ACCOUNT = "could_not_load_account";
-    public static String CONNECTION_ERROR = "api_connection_error";
-    public static String LENT_UNTIL = "lent_until";
-    public static String SUBTITLE = "subtitle";
-    public static String PICA_WHICH_COPY = "pica_which_copy";
-    public static String NO_COPY_RESERVABLE = "no_copy_reservable";
-    public static String COULD_NOT_LOAD_DETAIL = "could_not_load_detail";
-    public static String ERROR = "error";
-    public static String DOWNLOAD = "download";
-    public static String REMINDERS = "reminders";
-    public static String PROLONGED_ABBR = "prolonged_abbr";
-    public static String FREE_SEARCH = "free_search";
-    public static String WRONG_LOGIN_DATA = "wrong_account_data";
-    public static String PROLONGING_IMPOSSIBLE = "prolonging_impossible";
-    public static String PROLONGING_EXPIRED = "prolonging_expired";
-    public static String PROLONGING_WAITING = "prolonging_expired";
-    public static String ORDER = "order";
-    public static String ORDER_DEFAULT = "order_default";
-    public static String ORDER_YEAR_ASC = "order_year_asc";
-    public static String ORDER_CATEGORY_ASC = "order_category_asc";
-    public static String ORDER_YEAR_DESC = "order_year_desc";
-    public static String ORDER_CATEGORY_DESC = "order_category_desc";
-    public static String NO_RESULTS = "no_results";
-    public static String INTERLIB_BRANCH = "interlib_branch";
-    public static String STACKS_BRANCH = "stacks_branch";
-    public static String PROVISION_BRANCH = "provision_branch";
-    public static String UNSUPPORTED_IN_LIBRARY = "unsupported_in_library";
-    public static String RESERVATION_WARNING = "reservation_warning";
+    String INTERNAL_ERROR = "internal_error";
+    String INTERNAL_ERROR_WITH_DESCRIPTION = "internal_error_with_description";
+    String LOGIN_FAILED = "login_failed";
+    String COULD_NOT_LOAD_ACCOUNT = "could_not_load_account";
+    String CONNECTION_ERROR = "api_connection_error";
+    String LENT_UNTIL = "lent_until";
+    String SUBTITLE = "subtitle";
+    String PICA_WHICH_COPY = "pica_which_copy";
+    String NO_COPY_RESERVABLE = "no_copy_reservable";
+    String COULD_NOT_LOAD_DETAIL = "could_not_load_detail";
+    String ERROR = "error";
+    String DOWNLOAD = "download";
+    String REMINDERS = "reminders";
+    String PROLONGED_ABBR = "prolonged_abbr";
+    String FREE_SEARCH = "free_search";
+    String WRONG_LOGIN_DATA = "wrong_account_data";
+    String PROLONGING_IMPOSSIBLE = "prolonging_impossible";
+    String PROLONGING_EXPIRED = "prolonging_expired";
+    String PROLONGING_WAITING = "prolonging_expired";
+    String ORDER = "order";
+    String ORDER_DEFAULT = "order_default";
+    String ORDER_YEAR_ASC = "order_year_asc";
+    String ORDER_CATEGORY_ASC = "order_category_asc";
+    String ORDER_YEAR_DESC = "order_year_desc";
+    String ORDER_CATEGORY_DESC = "order_category_desc";
+    String NO_RESULTS = "no_results";
+    String INTERLIB_BRANCH = "interlib_branch";
+    String STACKS_BRANCH = "stacks_branch";
+    String PROVISION_BRANCH = "provision_branch";
+    String UNSUPPORTED_IN_LIBRARY = "unsupported_in_library";
+    String RESERVATION_WARNING = "reservation_warning";
 
     /**
      * Returns the translated string identified by identifier
@@ -82,7 +82,7 @@ public interface StringProvider {
      * @param identifier The ID of the string
      * @return the translated string
      */
-    public abstract String getString(String identifier);
+    String getString(String identifier);
 
     /**
      * Returns a translated formatted string
@@ -91,7 +91,7 @@ public interface StringProvider {
      * @param args       Formatting arguments
      * @return the translated and formatted string
      */
-    public abstract String getFormattedString(String identifier, Object... args);
+    String getFormattedString(String identifier, Object... args);
 
     /**
      * Returns a translated quantity string
@@ -101,5 +101,7 @@ public interface StringProvider {
      * @param args       Formatting arguments
      * @return the translated and formatted string
      */
-    public abstract String getQuantityString(String identifier, int count, Object... args);
+    String getQuantityString(String identifier, int count, Object... args);
+
+
 }

--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/i18n/StringProvider.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/i18n/StringProvider.java
@@ -21,6 +21,8 @@
  */
 package de.geeksfactory.opacclient.i18n;
 
+import de.geeksfactory.opacclient.objects.SearchResult;
+
 /**
  * The StringProvider interface exposes an abstract method of translating strings from the OpacApi
  * classes. Since version 3.2.1, it is highly discouraged to hardcode any string into the OpacApi
@@ -103,5 +105,12 @@ public interface StringProvider {
      */
     String getQuantityString(String identifier, int count, Object... args);
 
+    /**
+     * Returns the localized name of a media type
+     *
+     * @param mediaType the MediaType
+     * @return the translated string
+     */
+    String getMediaTypeName(SearchResult.MediaType mediaType);
 
 }

--- a/opacclient/opacapp/build.gradle
+++ b/opacclient/opacapp/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     compile('ch.acra:acra:4.5.0') {
         exclude group: 'org.json', module: 'json'
     }
-    compile 'org.jsoup:jsoup:1.8.1'
+    compile 'org.jsoup:jsoup:1.8.3'
     compile 'com.github.machinarius:preferencefragment:0.1.1'
     compile 'com.android.support:design:22.2.1'
     compile 'com.android.support:support-v4:22.2.1'

--- a/opacclient/opacapp/src/main/assets/bibs/Allershausen.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Allershausen.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Allershausen",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Amberg.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Amberg.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Amberg",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Aschheim.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Aschheim.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Aschheim",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/BadAbbach.json
+++ b/opacclient/opacapp/src/main/assets/bibs/BadAbbach.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Bad Abbach",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/BadAibling.json
+++ b/opacclient/opacapp/src/main/assets/bibs/BadAibling.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Bad Aibling",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/BadBirnbach.json
+++ b/opacclient/opacapp/src/main/assets/bibs/BadBirnbach.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Bad Birnbach",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/BadHersfeld.json
+++ b/opacclient/opacapp/src/main/assets/bibs/BadHersfeld.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Bad Hersfeld",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/BadKissingen.json
+++ b/opacclient/opacapp/src/main/assets/bibs/BadKissingen.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Bad Kissingen",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/BadVilbel.json
+++ b/opacclient/opacapp/src/main/assets/bibs/BadVilbel.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Bad Vilbel",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/BadWildungen.json
+++ b/opacclient/opacapp/src/main/assets/bibs/BadWildungen.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Bad Wildungen",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Bad_Mergentheim.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Bad_Mergentheim.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Bad Mergentheim",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Bad_Salzuflen.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Bad_Salzuflen.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Bad Salzuflen",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Bad_Toelz.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Bad_Toelz.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Bad T\u00f6lz",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Bad_Vilbel.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Bad_Vilbel.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Bad Vilbel",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Baldham_Vaterstetten.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Baldham_Vaterstetten.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Baldham",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Baunatal.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Baunatal.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Baunatal",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Belin_BSH.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Belin_BSH.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Berlin",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Bergrheinfeld.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Bergrheinfeld.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Bergrheinfeld",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/BobenheimRoxheim.json
+++ b/opacclient/opacapp/src/main/assets/bibs/BobenheimRoxheim.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Bobenheim-Roxheim",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Boetzingen.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Boetzingen.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "B\u00f6tzingen",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Borken.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Borken.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Borken",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Borsdorf.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Borsdorf.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Borsdorf",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Bruck_idOpf.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Bruck_idOpf.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Bruck i.d. Opf.",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Bubenreuth.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Bubenreuth.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Bubenreuth",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Cadolzburg.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Cadolzburg.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Cadolzburg",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Denklingen.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Denklingen.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Denklingen",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Dettelbach.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Dettelbach.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Dettelbach",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/DettingenTeck.json
+++ b/opacclient/opacapp/src/main/assets/bibs/DettingenTeck.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Dettingen unter Teck",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Dietzhoelztal.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Dietzhoelztal.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Dietzh\u00f6lztal",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Dillenburg.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Dillenburg.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Dillenburg",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Donauwoerth.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Donauwoerth.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Donauw\u00f6rth",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Eisleben.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Eisleben.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Eisleben",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Eislingen.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Eislingen.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Eislingen",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Elsenfeld.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Elsenfeld.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Elsenfeld",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Eschwege.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Eschwege.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Eschwege",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Espelkamp.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Espelkamp.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Espelkamp",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Finsing.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Finsing.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Finsing",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Frammersbach.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Frammersbach.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Frammersbach",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Frankfurt_Oder.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Frankfurt_Oder.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Frankfurt (Oder)",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/FreibergNeckar.json
+++ b/opacclient/opacapp/src/main/assets/bibs/FreibergNeckar.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Freiberg am Neckar",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Friedberg_Bayern.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Friedberg_Bayern.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Friedberg",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Fuessen.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Fuessen.json
@@ -1,16 +1,16 @@
 {
-  "account_supported": false,
-  "api": "winbiap",
-  "city": "F\u00fcssen",
-  "country": "Deutschland",
-  "data": {
-    "baseurl": "https://cloudopac.winbiap.de/fuessen"
-  },
-  "geo": [
-    47.569648,
-    10.7004328
-  ],
-  "information": "https://www.stadt-fuessen.de/bibliothek.html",
-  "state": "Bayern",
-  "title": "Stadtbibliothek"
+    "account_supported": true,
+    "api": "winbiap",
+    "city": "F\u00fcssen",
+    "country": "Deutschland",
+    "data": {
+        "baseurl": "https://cloudopac.winbiap.de/fuessen"
+    },
+    "geo": [
+        47.569648,
+        10.7004328
+    ],
+    "information": "https://www.stadt-fuessen.de/bibliothek.html",
+    "state": "Bayern",
+    "title": "Stadtbibliothek"
 }

--- a/opacclient/opacapp/src/main/assets/bibs/Fuldatal.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Fuldatal.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Fuldatal",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Gaimersheim.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Gaimersheim.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Gaimersheim",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Geislingen.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Geislingen.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Geislingen",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Geltendorf.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Geltendorf.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Geltendorf",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Gerbrunn.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Gerbrunn.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Gerbrunn",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Gerolzhofen.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Gerolzhofen.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Gerolzhofen",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Gersthofen.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Gersthofen.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Gersthofen",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Goeppingen.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Goeppingen.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "G\u00f6ppingen",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Graefelfing.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Graefelfing.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Gr\u00e4felfing",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Grasbrunn.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Grasbrunn.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Grasbrunn",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Grossenseebach.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Grossenseebach.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Gro\u00dfenseebach",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Grosskrotzenburg.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Grosskrotzenburg.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Gro\u00dfkrotzenburg",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Guenzburg.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Guenzburg.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "G\u00fcnzburg",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Guetersloh.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Guetersloh.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "G\u00fctersloh",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Gunzenhausen.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Gunzenhausen.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Gunzenhausen",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Gutersloh.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Gutersloh.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "G\u00fctersloh",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Haar.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Haar.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Haar",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Hallbergmoos.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Hallbergmoos.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Hallbergmoos",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Happurg.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Happurg.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Happurg",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Hassfurt.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Hassfurt.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Ha\u00dffurt",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Helmbrechts.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Helmbrechts.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Helmbrechts",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Herborn.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Herborn.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Herborn",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Heroldsberg.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Heroldsberg.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Heroldsberg",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Herzogenaurach.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Herzogenaurach.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Herzogenaurach",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Hoechberg.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Hoechberg.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "H\u00f6chberg",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/HoechstadtAisch.json
+++ b/opacclient/opacapp/src/main/assets/bibs/HoechstadtAisch.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "H\u00f6chstadt a. d. Aisch",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Hoesbach.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Hoesbach.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "H\u00f6sbach",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Hofgeismar.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Hofgeismar.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Hofgeismar",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/HohenNeuendorf.json
+++ b/opacclient/opacapp/src/main/assets/bibs/HohenNeuendorf.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Hohen Neuendorf",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Hungen.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Hungen.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Hungen",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Ismaning.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Ismaning.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Ismaning",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Jesteburg.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Jesteburg.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Jesteburg",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Karlsfeld.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Karlsfeld.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Karlsfeld",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Karlstadt.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Karlstadt.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Karlstadt",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Karlstein.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Karlstein.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Karlstein a. Main",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Kassel.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Kassel.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Kassel",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Kaufering.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Kaufering.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Kaufering",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/KaufungenNiederkaufungen.json
+++ b/opacclient/opacapp/src/main/assets/bibs/KaufungenNiederkaufungen.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Kaufungen",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Kierspe.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Kierspe.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Kierspe",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/KirchheimMuenchen.json
+++ b/opacclient/opacapp/src/main/assets/bibs/KirchheimMuenchen.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Kirchheim b. M\u00fcnchen",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/KirchheimTeck.json
+++ b/opacclient/opacapp/src/main/assets/bibs/KirchheimTeck.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Kirchheim u. Teck",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Kirchseeon.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Kirchseeon.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Kirchseeon",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Kist.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Kist.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Kist",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Kitzingen.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Kitzingen.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Kitzingen",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Knetzgau.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Knetzgau.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Knetzgau",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Koesching.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Koesching.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "K\u00f6sching",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Kolbermoor.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Kolbermoor.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Kolbermoor",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Kuenzell.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Kuenzell.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "K\u00fcnzell",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Kulmbach.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Kulmbach.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Kulmbach",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Landsberg.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Landsberg.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Landsberg",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Langenzenn.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Langenzenn.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Langenzenn",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Lauingen.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Lauingen.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Lauingen (Donau)",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Lemfoerde.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Lemfoerde.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Lemf\u00f6rde",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Lemgo.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Lemgo.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Lemgo",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Lenggries.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Lenggries.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Lenggries",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Leutershausen.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Leutershausen.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Leutershausen",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Lich.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Lich.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Lich",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Lindau.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Lindau.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Lindau",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Lippstadt.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Lippstadt.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Lippstadt",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Lohfelden.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Lohfelden.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Lohfelden",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Maisach.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Maisach.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Maisach",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Marktheidenfeld.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Marktheidenfeld.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Marktheidenfeld",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/MaxhuetteHaidhof.json
+++ b/opacclient/opacapp/src/main/assets/bibs/MaxhuetteHaidhof.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Maxh\u00fctte-Haidhof",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Menden.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Menden.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Menden (Sauerland)",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Mertingen.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Mertingen.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Mertingen",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Meschede.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Meschede.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Meschede",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/MuehldorfInn.json
+++ b/opacclient/opacapp/src/main/assets/bibs/MuehldorfInn.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "M\u00fchldorf a. Inn",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Naila.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Naila.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Naila",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Nettersheim.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Nettersheim.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Nettersheim",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/NeuWulmstorf.json
+++ b/opacclient/opacapp/src/main/assets/bibs/NeuWulmstorf.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Neu Wulmstorf",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/NeuburgDonau.json
+++ b/opacclient/opacapp/src/main/assets/bibs/NeuburgDonau.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Neuburg a. d. Donau",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/NeustadtDonau.json
+++ b/opacclient/opacapp/src/main/assets/bibs/NeustadtDonau.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Neustadt a.d. Donau",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Nidda.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Nidda.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Nidda",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Niederneuching.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Niederneuching.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Niederneuching",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Niedernhausen.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Niedernhausen.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Niedernhausen",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Niestetal.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Niestetal.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Niestetal",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Nittendorf.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Nittendorf.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Nittendorf",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Oberammergau.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Oberammergau.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Oberammergau",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Oberding.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Oberding.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Oberding",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Oberkaufungen.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Oberkaufungen.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Kaufungen",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Obernburg.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Obernburg.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Obernburg",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Ochsenfurt.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Ochsenfurt.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Ochsenfurt",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Offenbach.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Offenbach.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Offenbach",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Olching.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Olching.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Olching",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Olsberg.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Olsberg.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Olsberg",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/OstheimRhoen.json
+++ b/opacclient/opacapp/src/main/assets/bibs/OstheimRhoen.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Ostheim v.d.Rh\u00f6n",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Pentling.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Pentling.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Pentling",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Planegg.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Planegg.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Planegg",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Pluederhausen.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Pluederhausen.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Pl\u00fcderhausen",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Poettmes.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Poettmes.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "P\u00f6ttmes",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Prittriching.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Prittriching.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Prittriching",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Randersacker.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Randersacker.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Randersacker",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Raubling.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Raubling.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Raubling",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Raunheim.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Raunheim.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Raunheim",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Rheinau.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Rheinau.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Rheinau",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Rietberg.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Rietberg.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Rietberg",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Rodenbach.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Rodenbach.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Rodenbach",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Roding.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Roding.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Roding",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Roedermark.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Roedermark.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "R\u00f6dermark",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Roethlein.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Roethlein.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "R\u00f6thlein",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Roettingen.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Roettingen.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "R\u00f6ttingen",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/RothenburgFulda.json
+++ b/opacclient/opacapp/src/main/assets/bibs/RothenburgFulda.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Rotenburg a. d. Fulda",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Scheidegg.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Scheidegg.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Scheidegg",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Schillingsfuerst.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Schillingsfuerst.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Schillingsf\u00fcrst",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Schoeneck.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Schoeneck.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Sch\u00f6neck",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Schwabmuenchen.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Schwabmuenchen.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Schwabm\u00fcnchen",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Schwerte.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Schwerte.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Schwerte",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Seligenstadt.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Seligenstadt.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Seligenstadt",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/SendenBayern.json
+++ b/opacclient/opacapp/src/main/assets/bibs/SendenBayern.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Senden (Bayern)",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Soest.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Soest.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Soest",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Sonthofen.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Sonthofen.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Sonthofen",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Stadtallendorf.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Stadtallendorf.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Stadtallendorf",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Straubing.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Straubing.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Straubing",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Suessen.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Suessen.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "S\u00fc\u00dfen",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Tapfheim.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Tapfheim.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Tapfheim",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Teublitz.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Teublitz.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Teublitz",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Thannhausen.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Thannhausen.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Thannhausen",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Unterfoehring.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Unterfoehring.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Unterf\u00f6hring",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Unterhaching.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Unterhaching.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Unterhaching",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Untermeitingen.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Untermeitingen.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Untermeitingen",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Untermerzbach.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Untermerzbach.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Untermerzbach",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Unterschleissheim.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Unterschleissheim.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Unterschlei\u00dfheim",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Usingen.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Usingen.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Usingen",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Veitsbronn.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Veitsbronn.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Veitsbronn",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Vellmar.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Vellmar.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Vellmar",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Vohburg.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Vohburg.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Vohburg",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Volkach.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Volkach.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Volkach",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Wackersdorf.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Wackersdorf.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Wackersdorf",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Wehringen.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Wehringen.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Wehringen",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Weissenburg.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Weissenburg.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Wei\u00dfenburg",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Wendelstein.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Wendelstein.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Wendelstein",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Wertheim.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Wertheim.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Wertheim",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Wickede.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Wickede.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Wickede",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Wiernsheim.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Wiernsheim.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Wiernsheim",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Winsheim.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Winsheim.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Wimsheim",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Woerth.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Woerth.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "W\u00f6rth",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/assets/bibs/Zwingenberg.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Zwingenberg.json
@@ -1,5 +1,5 @@
 {
-    "account_supported": false,
+    "account_supported": true,
     "api": "winbiap",
     "city": "Zwingenberg",
     "country": "Deutschland",

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/i18n/AndroidStringProvider.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/i18n/AndroidStringProvider.java
@@ -22,6 +22,7 @@
 package de.geeksfactory.opacclient.i18n;
 
 import de.geeksfactory.opacclient.OpacClient;
+import de.geeksfactory.opacclient.objects.SearchResult;
 
 public class AndroidStringProvider implements StringProvider {
     @Override
@@ -44,5 +45,13 @@ public class AndroidStringProvider implements StringProvider {
         int id = OpacClient.context.getResources().getIdentifier(identifier,
                 "plurals", OpacClient.context.getPackageName());
         return OpacClient.context.getResources().getQuantityString(id, count, args);
+    }
+
+    @Override
+    public String getMediaTypeName(SearchResult.MediaType mediaType) {
+        int id = OpacClient.context.getResources().getIdentifier("mediatype_"
+                        + mediaType.toString().toLowerCase(), "string",
+                OpacClient.context.getPackageName());
+        return OpacClient.context.getResources().getString(id);
     }
 }

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/storage/AccountDatabase.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/storage/AccountDatabase.java
@@ -41,6 +41,12 @@ public class AccountDatabase extends SQLiteOpenHelper {
     // CHANGE THIS
     public static final Map<String, String> COLUMNS_LENT;
     public static final Map<String, String> COLUMNS_RESERVATIONS;
+    public static final String TABLENAME_ACCOUNTS = "accounts";
+    public static final String TABLENAME_LENT = "accountdata_lent";
+    public static final String TABLENAME_RESERVATION = "accountdata_reservations";
+    public static final String TABLENAME_NOTIFIED = "notified";
+    private static final String DATABASE_NAME = "accounts.db";
+    private static final int DATABASE_VERSION = 21; // REPLACE ONUPGRADE IF YOU
 
     static {
         Map<String, String> aMap = new HashMap<>();
@@ -68,15 +74,9 @@ public class AccountDatabase extends SQLiteOpenHelper {
         bMap.put(AccountData.KEY_RESERVATION_TITLE, "title");
         bMap.put(AccountData.KEY_RESERVATION_BOOKING, "bookingurl");
         bMap.put(AccountData.KEY_RESERVATION_ID, "itemid");
+        bMap.put(AccountData.KEY_RESERVATION_FORMAT, "format");
         COLUMNS_RESERVATIONS = Collections.unmodifiableMap(bMap);
     }
-
-    public static final String TABLENAME_ACCOUNTS = "accounts";
-    public static final String TABLENAME_LENT = "accountdata_lent";
-    public static final String TABLENAME_RESERVATION = "accountdata_reservations";
-    public static final String TABLENAME_NOTIFIED = "notified";
-    private static final String DATABASE_NAME = "accounts.db";
-    private static final int DATABASE_VERSION = 20; // REPLACE ONUPGRADE IF YOU
 
     public AccountDatabase(Context context) {
         super(context, DATABASE_NAME, null, DATABASE_VERSION);
@@ -180,6 +180,11 @@ public class AccountDatabase extends SQLiteOpenHelper {
         if (oldVersion < 20) {
             // App version 3.0.1 to 3.0.2
             db.execSQL("alter table accounts add column warning text");
+        }
+        if (oldVersion < 21) {
+            // App version 4.1.11 to 4.1.12
+            // KEY_RESERVATION_FORMAT existed before but was missing in the DB
+            db.execSQL("alter table accountdata_reservations add column format text");
         }
 
 

--- a/opacclient/opacapp/src/main/res/values-de/strings_api_errors.xml
+++ b/opacclient/opacapp/src/main/res/values-de/strings_api_errors.xml
@@ -40,4 +40,37 @@
   <string name="provision_branch">Bereit: %s</string>
   <string name="unsupported_in_library">Diese Funktion wird in dieser Bibliothek nicht unterstützt.</string>
   <string name="reservation_warning">Für diese Vorbestellung fallen möglicherweise Gebühren an.</string>
+
+  <string name="mediatype_none">keiner</string>
+  <string name="mediatype_book">Buch</string>
+  <string name="mediatype_cd">CD</string>
+  <string name="mediatype_cd_software">Software-CD</string>
+  <string name="mediatype_cd_music">Musik-CD</string>
+  <string name="mediatype_dvd">DVD</string>
+  <string name="mediatype_movie">Film</string>
+  <string name="mediatype_audiobook">Hörbuch</string>
+  <string name="mediatype_package">Paket</string>
+  <string name="mediatype_game_console">Spiel für Spielkonsole</string>
+  <string name="mediatype_ebook">eBook</string>
+  <string name="mediatype_score_music">Musiknoten</string>
+  <string name="mediatype_package_books">Bücherpaket</string>
+  <string name="mediatype_unknown">unbekannt</string>
+  <string name="mediatype_newspaper">Zeitung</string>
+  <string name="mediatype_boardgame">Brettspiel</string>
+  <string name="mediatype_school_version">Schulversion</string>
+  <string name="mediatype_map">Karte</string>
+  <string name="mediatype_bluray">Blu-Ray Disc</string>
+  <string name="mediatype_audio_cassette">Audiokassete</string>
+  <string name="mediatype_art">Kunst</string>
+  <string name="mediatype_magazine">Zeitschrift</string>
+  <string name="mediatype_game_console_wii">Spiel für Wii-Konsole</string>
+  <string name="mediatype_game_console_nintendo">Spiel für Nintendo-Konsole</string>
+  <string name="mediatype_game_console_playstation">Spiel für PlayStation</string>
+  <string name="mediatype_game_console_xbox">Spiel für XBox</string>
+  <string name="mediatype_lp_record">Schallplatte</string>
+  <string name="mediatype_mp3">MP3</string>
+  <string name="mediatype_url">URL</string>
+  <string name="mediatype_evideo">eVideo</string>
+  <string name="mediatype_edoc">eDoc</string>
+  <string name="mediatype_eaudio">eAudio</string>
 </resources>

--- a/opacclient/opacapp/src/main/res/values/strings_api_errors.xml
+++ b/opacclient/opacapp/src/main/res/values/strings_api_errors.xml
@@ -40,4 +40,37 @@
     <string name="provision_branch">Provision: %s</string>
     <string name="unsupported_in_library">This feature is not supported in this library.</string>
     <string name="reservation_warning">This reservation might cost you a fee.</string>
+
+    <string name="mediatype_none">none</string>
+    <string name="mediatype_book">book</string>
+    <string name="mediatype_cd">CD</string>
+    <string name="mediatype_cd_software">software CD</string>
+    <string name="mediatype_cd_music">music CD</string>
+    <string name="mediatype_dvd">DVD</string>
+    <string name="mediatype_movie">movie</string>
+    <string name="mediatype_audiobook">audiobook</string>
+    <string name="mediatype_package">package</string>
+    <string name="mediatype_game_console">console game</string>
+    <string name="mediatype_ebook">eBook</string>
+    <string name="mediatype_score_music">sheet music</string>
+    <string name="mediatype_package_books">package of books</string>
+    <string name="mediatype_unknown">unknown</string>
+    <string name="mediatype_newspaper">newspaper</string>
+    <string name="mediatype_boardgame">board game</string>
+    <string name="mediatype_school_version">school version</string>
+    <string name="mediatype_map">map</string>
+    <string name="mediatype_bluray">Blu-Ray Disc</string>
+    <string name="mediatype_audio_cassette">audio cassette</string>
+    <string name="mediatype_art">art</string>
+    <string name="mediatype_magazine">magazine</string>
+    <string name="mediatype_game_console_wii">game for Wii console</string>
+    <string name="mediatype_game_console_nintendo">game for Nintendo console</string>
+    <string name="mediatype_game_console_playstation">game for PlayStation</string>
+    <string name="mediatype_game_console_xbox">game for XBox</string>
+    <string name="mediatype_lp_record">LP record</string>
+    <string name="mediatype_mp3">MP3</string>
+    <string name="mediatype_url">URL</string>
+    <string name="mediatype_evideo">eVideo</string>
+    <string name="mediatype_edoc">eDoc</string>
+    <string name="mediatype_eaudio">eAudio</string>
 </resources>


### PR DESCRIPTION
I added account support for WinBiap, tested in Menden.
For recognizing media types in the account view, I needed to add media type names to the StringProvider (48b9969). Maybe they are also useful in other places (for example as `contentDescription` attribute for the media type icons in the search results).