### PR TITLE
Fixes and improvements for Pica LBS

### DIFF
--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/PicaOld.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/PicaOld.java
@@ -361,10 +361,18 @@ public class PicaOld extends Pica {
 
         List<Map<String, String>> media = new ArrayList<>();
         List<Map<String, String>> reserved = new ArrayList<>();
-        if (doc.select("table[summary^=list]").size() > 0) {
+        if (doc.select("table[summary^=list]").size() > 0
+                && !doc.select(".alert").text().contains("Keine Entleihungen")
+                && !doc.select(".alert").text().contains("No outstanding loans")
+                && !doc.select(".alert").text().contains("Geen uitlening")
+                && !doc.select(".alert").text().contains("Aucun emprunt")) {
             parse_medialist(media, doc);
         }
-        if (doc2.select("table[summary^=list]").size() > 0) {
+        if (doc2.select("table[summary^=list]").size() > 0
+                && !doc2.select(".alert").text().contains("Keine Vormerkungen")
+                && !doc2.select(".alert").text().contains("No outstanding reservations")
+                && !doc2.select(".alert").text().contains("Geen reservering")
+                && !doc2.select(".alert").text().contains("Aucune réservation")) {
             parse_reslist(reserved, doc2);
         }
 

--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/i18n/StringProvider.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/i18n/StringProvider.java
@@ -77,6 +77,8 @@ public interface StringProvider {
     String PROVISION_BRANCH = "provision_branch";
     String UNSUPPORTED_IN_LIBRARY = "unsupported_in_library";
     String RESERVATION_WARNING = "reservation_warning";
+    String RESERVATIONS_NUMBER = "reservations_number";
+    String RESERVED_AT_DATE = "reserved_at_date";
 
     /**
      * Returns the translated string identified by identifier

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/storage/AccountDatabase.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/storage/AccountDatabase.java
@@ -46,7 +46,7 @@ public class AccountDatabase extends SQLiteOpenHelper {
     public static final String TABLENAME_RESERVATION = "accountdata_reservations";
     public static final String TABLENAME_NOTIFIED = "notified";
     private static final String DATABASE_NAME = "accounts.db";
-    private static final int DATABASE_VERSION = 21; // REPLACE ONUPGRADE IF YOU
+    private static final int DATABASE_VERSION = 22; // REPLACE ONUPGRADE IF YOU
 
     static {
         Map<String, String> aMap = new HashMap<>();
@@ -99,7 +99,7 @@ public class AccountDatabase extends SQLiteOpenHelper {
                 + "accountdata_reservations ( account integer, "
                 + "title text," + "author text," + "ready text,"
                 + "branch text," + "cancel text," + "expire text,"
-                + "itemid text," + "bookingurl text);");
+                + "itemid text," + "bookingurl text," + "format text" + ");");
         db.execSQL("create table "
                 + "notified ( id integer primary key autoincrement, "
                 + "account integer, " + "timestamp integer);");
@@ -182,9 +182,19 @@ public class AccountDatabase extends SQLiteOpenHelper {
             db.execSQL("alter table accounts add column warning text");
         }
         if (oldVersion < 21) {
-            // App version 4.1.11 to 4.1.12
+            // App version 4.1.11 to 4.2.0
             // KEY_RESERVATION_FORMAT existed before but was missing in the DB
             db.execSQL("alter table accountdata_reservations add column format text");
+        }
+        if (oldVersion < 22) {
+            // App version 4.2.0 to 4.2.1
+            // We added KEY_RESERVATION_FORMAT to onUpgrade but didn't in onCreate,
+            // so we need to fix this by adding it again if it does not exist
+            try {
+                db.execSQL("alter table accountdata_reservations add column format text");
+            } catch (Exception e) {
+                // it already exists, do nothing
+            }
         }
 
 

--- a/opacclient/opacapp/src/main/res/layout/listitem_account_lent.xml
+++ b/opacclient/opacapp/src/main/res/layout/listitem_account_lent.xml
@@ -15,77 +15,75 @@
 
     <LinearLayout
         android:id="@+id/llData"
-        android:layout_gravity="center_vertical"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
         android:layout_weight="1"
-        android:paddingTop="4dp"
-        android:paddingBottom="4dp"
-        android:orientation="vertical"
+        android:animateLayoutChanges="true"
         android:clickable="false"
-        android:animateLayoutChanges="true">
+        android:orientation="vertical"
+        android:paddingBottom="4dp"
+        android:paddingTop="4dp">
 
         <TextView
             android:id="@+id/tvTitleAndAuthor"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:ellipsize="end"
-            android:singleLine="true"
+            android:contentDescription="@string/title_and_author"
             android:drawableLeft="@drawable/ic_title"
             android:drawablePadding="4dp"
+            android:ellipsize="end"
             android:gravity="center_vertical"
-            android:contentDescription="@string/title_and_author"/>
+            android:singleLine="true"/>
 
         <TextView
             android:id="@+id/tvStatus"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:ellipsize="end"
-            android:singleLine="true"
+            android:contentDescription="@string/status"
             android:drawableLeft="@drawable/ic_status"
             android:drawablePadding="4dp"
-            android:gravity="center_vertical"
-            android:contentDescription="@string/status"/>
+            android:gravity="center_vertical"/>
 
         <LinearLayout
             android:id="@+id/llDetails"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:visibility="gone"
-            android:orientation="vertical">
+            android:orientation="vertical"
+            android:visibility="gone">
 
             <TextView
                 android:id="@+id/tvAuthorDetail"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:ellipsize="end"
-                android:singleLine="true"
+                android:contentDescription="@string/author"
                 android:drawableLeft="@drawable/ic_author"
                 android:drawablePadding="4dp"
+                android:ellipsize="end"
                 android:gravity="center_vertical"
-                android:contentDescription="@string/author"/>
+                android:singleLine="true"/>
 
             <TextView
                 android:id="@+id/tvBranchDetail"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:ellipsize="end"
-                android:singleLine="true"
+                android:contentDescription="@string/branch"
                 android:drawableLeft="@drawable/ic_branch"
                 android:drawablePadding="4dp"
+                android:ellipsize="end"
                 android:gravity="center_vertical"
-                android:contentDescription="@string/branch"/>
+                android:singleLine="true"/>
 
             <TextView
                 android:id="@+id/tvFormatDetail"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:ellipsize="end"
-                android:singleLine="true"
+                android:contentDescription="@string/mediatype"
                 android:drawableLeft="@drawable/ic_media_type"
                 android:drawablePadding="4dp"
+                android:ellipsize="end"
                 android:gravity="center_vertical"
-                android:contentDescription="@string/mediatype"/>
+                android:singleLine="true"/>
         </LinearLayout>
     </LinearLayout>
 
@@ -93,39 +91,39 @@
         android:id="@+id/llButtons"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:animateLayoutChanges="true">
+        android:animateLayoutChanges="true"
+        android:orientation="vertical">
 
         <ImageView
             android:id="@+id/ivProlong"
             android:layout_width="48dp"
             android:layout_height="48dp"
-            android:contentDescription="@string/prolong"
-            android:src="@drawable/ic_prolong"
+            android:background="@drawable/ripple_unmasked"
             android:clickable="true"
+            android:contentDescription="@string/prolong"
             android:focusable="true"
-            android:background="@drawable/ripple_unmasked"/>
+            android:src="@drawable/ic_prolong"/>
 
         <ImageView
             android:id="@+id/ivDownload"
             android:layout_width="48dp"
             android:layout_height="48dp"
-            android:contentDescription="@string/download"
-            android:src="@drawable/ic_download"
-            android:visibility="gone"
+            android:background="@drawable/ripple_unmasked"
             android:clickable="true"
+            android:contentDescription="@string/download"
             android:focusable="true"
-            android:background="@drawable/ripple_unmasked"/>
+            android:src="@drawable/ic_download"
+            android:visibility="gone"/>
 
         <ImageView
             android:id="@+id/ivDetails"
             android:layout_width="48dp"
             android:layout_height="48dp"
-            android:contentDescription="@string/go_to_details"
-            android:src="@drawable/ic_detail"
-            android:visibility="gone"
+            android:background="@drawable/ripple_unmasked"
             android:clickable="true"
+            android:contentDescription="@string/go_to_details"
             android:focusable="true"
-            android:background="@drawable/ripple_unmasked"/>
+            android:src="@drawable/ic_detail"
+            android:visibility="gone"/>
     </LinearLayout>
 </LinearLayout>

--- a/opacclient/opacapp/src/main/res/layout/listitem_account_reservation.xml
+++ b/opacclient/opacapp/src/main/res/layout/listitem_account_reservation.xml
@@ -9,78 +9,76 @@
 
     <LinearLayout
         android:id="@+id/llData"
-        android:layout_gravity="center_vertical"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
+        android:layout_gravity="center_vertical"
         android:layout_marginLeft="12dp"
-        android:paddingTop="4dp"
-        android:paddingBottom="4dp"
-        android:orientation="vertical"
+        android:layout_weight="1"
+        android:animateLayoutChanges="true"
         android:clickable="false"
-        android:animateLayoutChanges="true">
+        android:orientation="vertical"
+        android:paddingBottom="4dp"
+        android:paddingTop="4dp">
 
         <TextView
             android:id="@+id/tvTitleAndAuthor"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:ellipsize="end"
-            android:singleLine="true"
+            android:contentDescription="@string/title_and_author"
             android:drawableLeft="@drawable/ic_title"
             android:drawablePadding="4dp"
+            android:ellipsize="end"
             android:gravity="center_vertical"
-            android:contentDescription="@string/title_and_author"/>
+            android:singleLine="true"/>
 
         <TextView
             android:id="@+id/tvStatus"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:ellipsize="end"
-            android:singleLine="true"
+            android:contentDescription="@string/status"
             android:drawableLeft="@drawable/ic_status"
             android:drawablePadding="4dp"
-            android:gravity="center_vertical"
-            android:contentDescription="@string/status"/>
+            android:gravity="center_vertical"/>
 
         <LinearLayout
             android:id="@+id/llDetails"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:visibility="gone"
-            android:orientation="vertical">
+            android:orientation="vertical"
+            android:visibility="gone">
 
             <TextView
                 android:id="@+id/tvAuthorDetail"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:ellipsize="end"
-                android:singleLine="true"
+                android:contentDescription="@string/author"
                 android:drawableLeft="@drawable/ic_author"
                 android:drawablePadding="4dp"
+                android:ellipsize="end"
                 android:gravity="center_vertical"
-                android:contentDescription="@string/author"/>
+                android:singleLine="true"/>
 
             <TextView
                 android:id="@+id/tvBranchDetail"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:ellipsize="end"
-                android:singleLine="true"
+                android:contentDescription="@string/branch"
                 android:drawableLeft="@drawable/ic_branch"
                 android:drawablePadding="4dp"
+                android:ellipsize="end"
                 android:gravity="center_vertical"
-                android:contentDescription="@string/branch"/>
+                android:singleLine="true"/>
 
             <TextView
                 android:id="@+id/tvFormatDetail"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:ellipsize="end"
-                android:singleLine="true"
+                android:contentDescription="@string/mediatype"
                 android:drawableLeft="@drawable/ic_media_type"
                 android:drawablePadding="4dp"
+                android:ellipsize="end"
                 android:gravity="center_vertical"
-                android:contentDescription="@string/mediatype"/>
+                android:singleLine="true"/>
         </LinearLayout>
     </LinearLayout>
 
@@ -88,39 +86,39 @@
         android:id="@+id/llButtons"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:animateLayoutChanges="true">
+        android:animateLayoutChanges="true"
+        android:orientation="vertical">
 
         <ImageView
             android:id="@+id/ivCancel"
             android:layout_width="48dp"
             android:layout_height="48dp"
-            android:contentDescription="@string/reservation_cancel"
-            android:src="@drawable/ic_cancel"
+            android:background="@drawable/ripple_unmasked"
             android:clickable="true"
+            android:contentDescription="@string/reservation_cancel"
             android:focusable="true"
-            android:background="@drawable/ripple_unmasked"/>
+            android:src="@drawable/ic_cancel"/>
 
         <ImageView
             android:id="@+id/ivBooking"
             android:layout_width="48dp"
             android:layout_height="48dp"
-            android:contentDescription="@string/reservation_book"
-            android:src="@drawable/ic_booking"
-            android:visibility="gone"
+            android:background="@drawable/ripple_unmasked"
             android:clickable="true"
+            android:contentDescription="@string/reservation_book"
             android:focusable="true"
-            android:background="@drawable/ripple_unmasked"/>
+            android:src="@drawable/ic_booking"
+            android:visibility="gone"/>
 
         <ImageView
             android:id="@+id/ivDetails"
             android:layout_width="48dp"
             android:layout_height="48dp"
-            android:visibility="gone"
-            android:contentDescription="@string/go_to_details"
-            android:src="@drawable/ic_detail"
+            android:background="@drawable/ripple_unmasked"
             android:clickable="true"
+            android:contentDescription="@string/go_to_details"
             android:focusable="true"
-            android:background="@drawable/ripple_unmasked"/>
+            android:src="@drawable/ic_detail"
+            android:visibility="gone"/>
     </LinearLayout>
 </LinearLayout>

--- a/opacclient/opacapp/src/main/res/values-de/strings_api_errors.xml
+++ b/opacclient/opacapp/src/main/res/values-de/strings_api_errors.xml
@@ -40,6 +40,8 @@
   <string name="provision_branch">Bereit: %s</string>
   <string name="unsupported_in_library">Diese Funktion wird in dieser Bibliothek nicht unterstützt.</string>
   <string name="reservation_warning">Für diese Vorbestellung fallen möglicherweise Gebühren an.</string>
+  <string name="reservations_number">%s Reservierungen</string>
+  <string name="reserved_at_date">res. am %s</string>
 
   <string name="mediatype_none">keiner</string>
   <string name="mediatype_book">Buch</string>

--- a/opacclient/opacapp/src/main/res/values/strings_api_errors.xml
+++ b/opacclient/opacapp/src/main/res/values/strings_api_errors.xml
@@ -40,6 +40,8 @@
     <string name="provision_branch">Provision: %s</string>
     <string name="unsupported_in_library">This feature is not supported in this library.</string>
     <string name="reservation_warning">This reservation might cost you a fee.</string>
+    <string name="reservations_number">%s reservations</string>
+    <string name="reserved_at_date">res. at %s</string>
 
     <string name="mediatype_none">none</string>
     <string name="mediatype_book">book</string>


### PR DESCRIPTION
Issues were reported with our new Pica LBS implementation (including the same media name being displayed for all the lent media). This is fixed here. In addition, I enabled the status in the account view to be able to take up multiple lines (this can happen when error messages like "too many renewals" or "this volume has a reservation" need to be displayed there in addition to the return/reservation date).