### PR TITLE
Introduce DropdownSearchField.Option

### DIFF
--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/Adis.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/Adis.java
@@ -1437,12 +1437,8 @@ public class Adis extends BaseApi implements OpacApi {
                 field.setDisplayName(row.select("label").first().text());
                 List<Map<String, String>> values = new ArrayList<>();
                 for (Element opt : select.select("option")) {
-                    Map<String, String> value = new HashMap<>();
-                    value.put("key", opt.attr("value"));
-                    value.put("value", opt.text());
-                    values.add(value);
+                    field.addDropdownValue(opt.attr("value"), opt.text());
                 }
-                field.setDropdownValues(values);
                 fields.add(field);
             } else if (row.select("select").size() == 0
                     && row.select("input[type=text]").size() == 3

--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/BiBer1992.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/BiBer1992.java
@@ -178,7 +178,6 @@ public class BiBer1992 extends BaseApi {
             DropdownSearchField mtDropdown = new DropdownSearchField();
             mtDropdown.setId(mt_opts.get(0).attr("name"));
             mtDropdown.setDisplayName("Medientyp");
-            List<Map<String, String>> mtOptions = new ArrayList<>();
             for (Element opt : mt_opts) {
                 if (!opt.val().equals("")) {
                     String text = opt.text();
@@ -225,13 +224,9 @@ public class BiBer1992 extends BaseApi {
                         // text is still empty: missing end tag like Offenburg
                         text = parse_option_regex(opt);
                     }
-                    Map<String, String> value = new HashMap<>();
-                    value.put("key", opt.val());
-                    value.put("value", text);
-                    mtOptions.add(value);
+                    mtDropdown.addDropdownValue(opt.val(), text);
                 }
             }
-            mtDropdown.setDropdownValues(mtOptions);
             fields.add(mtDropdown);
         }
 
@@ -243,14 +238,9 @@ public class BiBer1992 extends BaseApi {
             brDropdown.setDisplayName(br_opts.get(0).parent().parent()
                                              .previousElementSibling().text().replace("\u00a0", "")
                                              .replace("?", "").trim());
-            List<Map<String, String>> brOptions = new ArrayList<>();
             for (Element opt : br_opts) {
-                Map<String, String> value = new HashMap<>();
-                value.put("key", opt.val());
-                value.put("value", opt.text());
-                brOptions.add(value);
+                brDropdown.addDropdownValue(opt.val(), opt.text());
             }
-            brDropdown.setDropdownValues(brOptions);
             fields.add(brDropdown);
         }
 

--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/Bibliotheca.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/Bibliotheca.java
@@ -195,35 +195,14 @@ public class Bibliotheca extends BaseApi {
             }
         }
 
-        List<Map<String, String>> dropdownValues = new ArrayList<>();
-        Map<String, String> valueMap = new HashMap<>();
-        valueMap.put("key", "1");
-        valueMap.put("value",
-                stringProvider.getString(StringProvider.ORDER_DEFAULT));
-        dropdownValues.add(valueMap);
-        valueMap = new HashMap<>();
-        valueMap.put("key", "2:desc");
-        valueMap.put("value",
-                stringProvider.getString(StringProvider.ORDER_YEAR_DESC));
-        dropdownValues.add(valueMap);
-        valueMap = new HashMap<>();
-        valueMap.put("key", "2:asc");
-        valueMap.put("value",
-                stringProvider.getString(StringProvider.ORDER_YEAR_ASC));
-        dropdownValues.add(valueMap);
-        valueMap = new HashMap<>();
-        valueMap.put("key", "3:desc");
-        valueMap.put("value",
-                stringProvider.getString(StringProvider.ORDER_CATEGORY_DESC));
-        dropdownValues.add(valueMap);
-        valueMap = new HashMap<>();
-        valueMap.put("key", "3:asc");
-        valueMap.put("value",
-                stringProvider.getString(StringProvider.ORDER_CATEGORY_ASC));
-        dropdownValues.add(valueMap);
         DropdownSearchField orderField = new DropdownSearchField("orderselect",
                 stringProvider.getString(StringProvider.ORDER), false,
-                dropdownValues);
+                null);
+        orderField.addDropdownValue("1", stringProvider.getString(StringProvider.ORDER_DEFAULT));
+        orderField.addDropdownValue("2:desc", stringProvider.getString(StringProvider.ORDER_YEAR_DESC));
+        orderField.addDropdownValue("2:asc", stringProvider.getString(StringProvider.ORDER_YEAR_ASC));
+        orderField.addDropdownValue("3:desc", stringProvider.getString(StringProvider.ORDER_CATEGORY_DESC));
+        orderField.addDropdownValue("3:asc", stringProvider.getString(StringProvider.ORDER_CATEGORY_ASC));
         orderField.setMeaning(Meaning.ORDER);
         fields.add(orderField);
 
@@ -243,14 +222,9 @@ public class Bibliotheca extends BaseApi {
             DropdownSearchField field = new DropdownSearchField();
             field.setDisplayName(name);
             field.setId(input.attr("name"));
-            List<Map<String, String>> options = new ArrayList<>();
             for (Element option : input.select("option")) {
-                Map<String, String> map = new HashMap<>();
-                map.put("key", option.attr("value"));
-                map.put("value", option.text());
-                options.add(map);
+                field.addDropdownValue(option.attr("value"), option.text());
             }
-            field.setDropdownValues(options);
             return field;
         } else {
             return null;

--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/Heidi.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/Heidi.java
@@ -470,28 +470,22 @@ public class Heidi extends BaseApi implements OpacApi {
         }
 
         DropdownSearchField field = new DropdownSearchField();
-        List<Map<String, String>> opts = new ArrayList<>();
 
         Elements zst_opts = doc.select("#teilk2 option");
         for (int i = 0; i < zst_opts.size(); i++) {
             Element opt = zst_opts.get(i);
             if (!opt.val().equals("")) {
-                Map<String, String> option = new HashMap<>();
-                option.put("key", opt.val());
-                option.put("value", opt.text());
-                opts.add(option);
+                field.addDropdownValue(opt.val(), opt.text());
             }
         }
         field.setDisplayName("Einrichtung");
         field.setId("f[teil2]");
         field.setVisible(true);
         field.setMeaning(SearchField.Meaning.BRANCH);
-        field.setDropdownValues(opts);
         fields.add(field);
 
         try {
             field = new DropdownSearchField();
-            opts = new ArrayList<>();
             Document doc2 = Jsoup.parse(httpGet(opac_url
                             + "/zweigstelle.cgi?sess=" + sessid, ENCODING, false,
                     cookieStore));
@@ -502,14 +496,13 @@ public class Heidi extends BaseApi implements OpacApi {
                     Map<String, String> option = new HashMap<>();
                     option.put("key", opt.val());
                     option.put("value", opt.text());
-                    opts.add(option);
+                    field.addDropdownValue(opt.val(), opt.text());
                 }
             }
             field.setDisplayName("Leihstelle");
             field.setId("_heidi_branch");
             field.setVisible(true);
             field.setMeaning(SearchField.Meaning.HOME_BRANCH);
-            field.setDropdownValues(opts);
             fields.add(field);
         } catch (IOException e) {
             e.printStackTrace();

--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/IOpac.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/IOpac.java
@@ -919,14 +919,9 @@ public class IOpac extends BaseApi implements OpacApi {
             DropdownSearchField field = new DropdownSearchField();
             field.setDisplayName(name);
             field.setId(select.attr("name"));
-            List<Map<String, String>> options = new ArrayList<>();
             for (Element option : select.select("option")) {
-                Map<String, String> map = new HashMap<>();
-                map.put("key", option.attr("value"));
-                map.put("value", option.text());
-                options.add(map);
+                field.addDropdownValue(option.attr("value"), option.text());
             }
-            field.setDropdownValues(options);
             return field;
         } else if (inputTd.select("input").size() > 0) {
             TextSearchField field = new TextSearchField();
@@ -996,7 +991,7 @@ public class IOpac extends BaseApi implements OpacApi {
         Pattern pattern_value = Pattern
                 .compile("mtyp\\[[0-9]+\\]\\[\"bez\"\\] = \"([^\"]+)\";");
 
-        List<Map<String, String>> mediatypes = new ArrayList<>();
+        DropdownSearchField mtyp = new DropdownSearchField();
         try {
             html = httpGet(opac_url + dir + "/mtyp.js", getDefaultEncoding());
 
@@ -1013,10 +1008,7 @@ public class IOpac extends BaseApi implements OpacApi {
                     value = matcher2.group(1);
                 }
                 if (!value.equals("")) {
-                    Map<String, String> mediatype = new HashMap<>();
-                    mediatype.put("key", key);
-                    mediatype.put("value", value);
-                    mediatypes.add(mediatype);
+                    mtyp.addDropdownValue(key, value);
                 }
             }
         } catch (IOException e) {
@@ -1027,10 +1019,7 @@ public class IOpac extends BaseApi implements OpacApi {
                 doc = Jsoup.parse(html);
 
                 for (Element opt : doc.select("#imtyp option")) {
-                    Map<String, String> mediatype = new HashMap<>();
-                    mediatype.put("key", opt.attr("value"));
-                    mediatype.put("value", opt.text());
-                    mediatypes.add(mediatype);
+                    mtyp.addDropdownValue(opt.attr("value"), opt.text());
                 }
 
             } catch (IOException e1) {
@@ -1038,11 +1027,9 @@ public class IOpac extends BaseApi implements OpacApi {
             }
 
         }
-        if (mediatypes.size() > 0) {
-            DropdownSearchField mtyp = new DropdownSearchField();
+        if (!mtyp.getDropdownValues().isEmpty()) {
             mtyp.setDisplayName("Medientypen");
             mtyp.setId("Medientyp");
-            mtyp.setDropdownValues(mediatypes);
             fields.add(mtyp);
         }
         return fields;

--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/Pica.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/Pica.java
@@ -726,14 +726,9 @@ public abstract class Pica extends BaseApi implements OpacApi {
             field.setDisplayName(sort.first().parent().parent()
                                      .select(".longval").first().text());
             field.setId("SRT");
-            List<Map<String, String>> sortOptions = new ArrayList<>();
             for (Element option : sort.select("option")) {
-                Map<String, String> sortOption = new HashMap<>();
-                sortOption.put("key", option.attr("value"));
-                sortOption.put("value", option.text());
-                sortOptions.add(sortOption);
+                field.addDropdownValue(option.attr("value"), option.text());
             }
-            field.setDropdownValues(sortOptions);
             fields.add(field);
         }
 
@@ -750,16 +745,11 @@ public abstract class Pica extends BaseApi implements OpacApi {
         for (Element dropdown : doc.select("select[name^=ADI]")) {
             DropdownSearchField field = new DropdownSearchField();
             field.setDisplayName(dropdown.parent().parent().select(".longkey")
-                                         .text());
+                    .text());
             field.setId(dropdown.attr("name"));
-            List<Map<String, String>> dropdownOptions = new ArrayList<>();
             for (Element option : dropdown.select("option")) {
-                Map<String, String> dropdownOption = new HashMap<>();
-                dropdownOption.put("key", option.attr("value"));
-                dropdownOption.put("value", option.text());
-                dropdownOptions.add(dropdownOption);
+                field.addDropdownValue(option.attr("value"), option.text());
             }
-            field.setDropdownValues(dropdownOptions);
             fields.add(field);
         }
 
@@ -778,19 +768,11 @@ public abstract class Pica extends BaseApi implements OpacApi {
             field.setDisplayName("Materialart");
             field.setId("ADI_MAT");
 
-            List<Map<String, String>> values = new ArrayList<>();
-            Map<String, String> all = new HashMap<>();
-            all.put("key", "");
-            all.put("value", "Alle");
-            values.add(all);
+            field.addDropdownValue("", "Alle");
             for (Element mt : mediatypes) {
-                Map<String, String> value = new HashMap<>();
-                value.put("key", mt.attr("value"));
-                value.put("value", mt.parent().nextElementSibling().text()
-                                     .replace("\u00a0", ""));
-                values.add(value);
+                field.addDropdownValue(mt.attr("value"),
+                        mt.parent().nextElementSibling().text().replace("\u00a0", ""));
             }
-            field.setDropdownValues(values);
             fields.add(field);
         }
 

--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/Primo.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/Primo.java
@@ -461,18 +461,13 @@ public class Primo extends BaseApi {
                 continue;
             }
             field.setId("#" + select.attr("id"));
-            List<Map<String, String>> dropdownOptions = new ArrayList<>();
             for (Element option : select.select("option")) {
-                Map<String, String> dropdownOption = new HashMap<>();
-                dropdownOption.put("key", option.val());
-                dropdownOption.put("value", option.text());
                 if (option.val().equals("all_items")) {
-                    dropdownOptions.add(0, dropdownOption);
+                    field.addDropdownValue(0, option.val(), option.text());
                 } else {
-                    dropdownOptions.add(dropdownOption);
+                    field.addDropdownValue(option.val(), option.text());
                 }
             }
-            field.setDropdownValues(dropdownOptions);
             field.setData(new JSONObject());
             field.getData().put("meaning", field.getId());
             fields.add(field);

--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/SISIS.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/SISIS.java
@@ -194,7 +194,6 @@ public class SISIS extends BaseApi implements OpacApi {
             List<SearchField> fields) throws JSONException {
         Elements options = dropdownElement.select("option");
         DropdownSearchField dropdown = new DropdownSearchField();
-        List<Map<String, String>> values = new ArrayList<>();
         if (dropdownElement.parent().select("input[type=hidden]").size() > 0) {
             dropdown.setId(dropdownElement.parent()
                                           .select("input[type=hidden]").attr("value"));
@@ -204,12 +203,8 @@ public class SISIS extends BaseApi implements OpacApi {
             dropdown.setData(new JSONObject("{\"restriction\": false}"));
         }
         for (Element option : options) {
-            Map<String, String> value = new HashMap<>();
-            value.put("key", option.attr("value"));
-            value.put("value", option.text());
-            values.add(value);
+            dropdown.addDropdownValue(option.attr("value"), option.text());
         }
-        dropdown.setDropdownValues(values);
         dropdown.setDisplayName(dropdownElement.parent().select("label").text());
         fields.add(dropdown);
     }

--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/TouchPoint.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/TouchPoint.java
@@ -191,7 +191,6 @@ public class TouchPoint extends BaseApi implements OpacApi {
             List<SearchField> fields) {
         Elements options = dropdownElement.select("option");
         DropdownSearchField dropdown = new DropdownSearchField();
-        List<Map<String, String>> values = new ArrayList<>();
         dropdown.setId(dropdownElement.attr("name"));
         // Some fields make no sense or are not supported in the app
         if (dropdown.getId().equals("numberOfHits")
@@ -200,12 +199,8 @@ public class TouchPoint extends BaseApi implements OpacApi {
             return;
         }
         for (Element option : options) {
-            Map<String, String> value = new HashMap<>();
-            value.put("key", option.attr("value"));
-            value.put("value", option.text());
-            values.add(value);
+            dropdown.addDropdownValue(option.attr("value"), option.text());
         }
-        dropdown.setDropdownValues(values);
         dropdown.setDisplayName(dropdownElement.parent().select("label").text());
         fields.add(dropdown);
     }

--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/VuFind.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/VuFind.java
@@ -478,20 +478,13 @@ public class VuFind extends BaseApi {
             field.setId(select.attr("name") + select.attr("id"));
             List<Map<String, String>> dropdownOptions = new ArrayList<>();
             String meaning = select.attr("id");
-            Map<String, String> emptyDropdownOption = new HashMap<>();
-            emptyDropdownOption.put("key", "");
-            emptyDropdownOption.put("value", "");
-            dropdownOptions.add(emptyDropdownOption);
+            field.addDropdownValue("", "");
             for (Element option : select.select("option")) {
                 if (option.val().contains(":")) {
                     meaning = option.val().split(":")[0];
                 }
-                Map<String, String> dropdownOption = new HashMap<>();
-                dropdownOption.put("key", option.val());
-                dropdownOption.put("value", option.text());
-                dropdownOptions.add(dropdownOption);
+                field.addDropdownValue(option.val(), option.text());
             }
-            field.setDropdownValues(dropdownOptions);
             field.setData(new JSONObject());
             field.getData().put("meaning", meaning);
             fields.add(field);

--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/WebOpacNet.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/WebOpacNet.java
@@ -422,22 +422,15 @@ public class WebOpacNet extends BaseApi implements OpacApi {
                 field.setDisplayName(filter.getString("kopf"));
 
                 JSONArray restrictions = filter.getJSONArray("restrictions");
-                List<Map<String, String>> values = new ArrayList<>();
 
-                Map<String, String> all = new HashMap<>();
-                all.put("key", "");
-                all.put("value", "Alle");
-                values.add(all);
+                field.addDropdownValue("", "Alle");
 
                 for (int j = 0; j < restrictions.length(); j++) {
                     JSONObject restriction = restrictions.getJSONObject(j);
-                    Map<String, String> value = new HashMap<>();
-                    value.put("key", restriction.getString("id"));
-                    value.put("value", restriction.getString("bez"));
-                    values.add(value);
+                    field.addDropdownValue(restriction.getString("id"),
+                            restriction.getString("bez"));
                 }
 
-                field.setDropdownValues(values);
                 field.setData(new JSONObject("{\"filter\":true}"));
                 fields.add(field);
             }

--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/WinBiap.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/WinBiap.java
@@ -801,26 +801,22 @@ public class WinBiap extends BaseApi implements OpacApi {
         Elements branchOptions = doc
                 .select("#ctl00_ContentPlaceHolderMain_searchPanel_MultiSelectionBranch_ListBoxMultiselection option");
 
-        List<Map<String, String>> mediaGroups = new ArrayList<>();
-        List<Map<String, String>> branches = new ArrayList<>();
+        final DropdownSearchField mediaGroups =
+                new DropdownSearchField(KEY_SEARCH_QUERY_CATEGORY, "Mediengruppe", false, null);
+        mediaGroups.setMeaning(Meaning.CATEGORY);
 
-        Map<String, String> all = new HashMap<>();
-        all.put("key", "");
-        all.put("value", "Alle");
-        mediaGroups.add(all);
-        branches.add(all);
+        final DropdownSearchField branches =
+                new DropdownSearchField(KEY_SEARCH_QUERY_BRANCH, "Zweigstelle", false, null);
+        branches.setMeaning(Meaning.BRANCH);
+
+        mediaGroups.addDropdownValue("", "Alle");
+        branches.addDropdownValue("", "Alle");
 
         for (Element option : mediaGroupOptions) {
-            Map<String, String> map = new HashMap<>();
-            map.put("key", option.attr("value"));
-            map.put("value", option.text());
-            mediaGroups.add(map);
+            mediaGroups.addDropdownValue(option.attr("value"), option.text());
         }
         for (Element option : branchOptions) {
-            Map<String, String> map = new HashMap<>();
-            map.put("key", option.attr("value"));
-            map.put("value", option.text());
-            branches.add(map);
+            branches.addDropdownValue(option.attr("value"), option.text());
         }
 
         List<SearchField> searchFields = new ArrayList<>();
@@ -880,15 +876,8 @@ public class WinBiap extends BaseApi implements OpacApi {
         field.setMeaning(Meaning.YEAR);
         searchFields.add(field);
 
-        field = new DropdownSearchField(KEY_SEARCH_QUERY_BRANCH, "Zweigstelle",
-                false, branches);
-        field.setMeaning(Meaning.BRANCH);
-        searchFields.add(field);
-
-        field = new DropdownSearchField(KEY_SEARCH_QUERY_CATEGORY,
-                "Mediengruppe", false, mediaGroups);
-        field.setMeaning(Meaning.CATEGORY);
-        searchFields.add(field);
+        searchFields.add(branches);
+        searchFields.add(mediaGroups);
 
         return searchFields;
     }

--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/Zones22.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/Zones22.java
@@ -129,21 +129,13 @@ public class Zones22 extends BaseApi {
         if (zst_opts.size() > 0) {
             DropdownSearchField brDropdown = new DropdownSearchField();
             brDropdown.setId(zst_opts.get(0).parent().select("input")
-                                     .attr("name"));
+                    .attr("name"));
             brDropdown.setDisplayName("Zweigstelle");
 
-            List<Map<String, String>> brOptions = new ArrayList<>();
-            Map<String, String> all = new HashMap<>();
-            all.put("key", "");
-            all.put("value", "Alle");
-            brOptions.add(all);
+            brDropdown.addDropdownValue("", "Alle");
             for (Element opt : zst_opts) {
-                Map<String, String> value = new HashMap<>();
-                value.put("key", opt.attr("for"));
-                value.put("value", opt.text().trim());
-                brOptions.add(value);
+                brDropdown.addDropdownValue(opt.attr("for"), opt.text().trim());
             }
-            brDropdown.setDropdownValues(brOptions);
             fields.add(brDropdown);
         }
 

--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/searchfields/DropdownSearchField.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/searchfields/DropdownSearchField.java
@@ -4,6 +4,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -13,7 +14,35 @@ import java.util.Map;
  */
 public class DropdownSearchField extends SearchField {
 
-    protected List<Map<String, String>> dropdownValues;
+    /**
+     * Represents a dropdown option.
+     */
+    public static class Option implements Map.Entry<String, String> {
+        private final String key;
+        private final String value;
+
+        public Option(String key, String value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        @Override
+        public String getKey() {
+            return key;
+        }
+
+        @Override
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public String setValue(String value) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    protected List<Option> dropdownValues;
 
     public DropdownSearchField() {
 
@@ -31,7 +60,7 @@ public class DropdownSearchField extends SearchField {
      *                       value and will not be given to the search() function
      */
     public DropdownSearchField(String id, String displayName, boolean advanced,
-                               List<Map<String, String>> dropdownValues) {
+                               List<Option> dropdownValues) {
         super(id, displayName, advanced);
         this.dropdownValues = dropdownValues;
     }
@@ -39,16 +68,29 @@ public class DropdownSearchField extends SearchField {
     /**
      * Get the list of selectable values.
      */
-    public List<Map<String, String>> getDropdownValues() {
+    public List<Option> getDropdownValues() {
         return dropdownValues;
     }
 
     /**
-     * Set a list of values for the dropdown list. Each value is a Map and
-     * should contain the keys 'key' and 'value'.
+     * Set a list of values for the dropdown list.
      */
-    public void setDropdownValues(List<Map<String, String>> dropdownValues) {
+    public void setDropdownValues(List<Option> dropdownValues) {
         this.dropdownValues = dropdownValues;
+    }
+
+    public void addDropdownValue(String key, String value) {
+        if (dropdownValues == null) {
+            dropdownValues = new ArrayList<>();
+        }
+        dropdownValues.add(new Option(key, value));
+    }
+
+    public void addDropdownValue(int index, String key, String value) {
+        if (dropdownValues == null) {
+            dropdownValues = new ArrayList<>();
+        }
+        dropdownValues.add(index, new Option(key, value));
     }
 
     @Override
@@ -56,10 +98,10 @@ public class DropdownSearchField extends SearchField {
         JSONObject json = super.toJSON();
         json.put("type", "dropdown");
         JSONArray values = new JSONArray();
-        for (Map<String, String> map : dropdownValues) {
+        for (Option map : dropdownValues) {
             JSONObject value = new JSONObject();
-            value.put("key", map.get("key"));
-            value.put("value", map.get("value"));
+            value.put("key", map.getKey());
+            value.put("value", map.getValue());
             values.put(value);
         }
         json.put("dropdownValues", values);

--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/searchfields/SearchField.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/searchfields/SearchField.java
@@ -4,11 +4,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * A SearchField is the abstract representation of a criteria input available in the search form.
@@ -80,17 +76,13 @@ public abstract class SearchField {
                 field = new CheckboxSearchField(id, displayName, advanced);
                 break;
             case "dropdown":
-                List<Map<String, String>> dropdownValues = new ArrayList<>();
                 JSONArray array = json.getJSONArray("dropdownValues");
+                field = new DropdownSearchField(id, displayName, advanced, null);
                 for (int i = 0; i < array.length(); i++) {
                     JSONObject value = array.getJSONObject(i);
-                    Map<String, String> map = new HashMap<>();
-                    map.put("key", value.getString("key"));
-                    map.put("value", value.getString("value"));
-                    dropdownValues.add(map);
+                    ((DropdownSearchField) field).addDropdownValue(
+                            value.getString("key"), value.getString("value"));
                 }
-                field = new DropdownSearchField(id, displayName, advanced,
-                        dropdownValues);
                 break;
         }
         if (field != null) {

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/OpacActivity.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/OpacActivity.java
@@ -657,12 +657,12 @@ public abstract class OpacActivity extends AppCompatActivity {
         }
     }
 
-    public class MetaAdapter extends ArrayAdapter<Map<String, String>> {
+    public class MetaAdapter<T extends Map.Entry<?, String>> extends ArrayAdapter<T> {
 
-        private List<Map<String, String>> objects;
+        private List<T> objects;
         private int spinneritem;
 
-        public MetaAdapter(Context context, List<Map<String, String>> objects,
+        public MetaAdapter(Context context, List<T> objects,
                 int spinneritem) {
             super(context, R.layout.simple_spinner_item, objects);
             this.objects = objects;
@@ -683,7 +683,7 @@ public abstract class OpacActivity extends AppCompatActivity {
                 return view;
             }
 
-            Map<String, String> item = objects.get(position);
+            T item = objects.get(position);
 
             if (contentView == null) {
                 LayoutInflater layoutInflater = (LayoutInflater) getContext()
@@ -696,7 +696,7 @@ public abstract class OpacActivity extends AppCompatActivity {
             }
 
             TextView tvText = (TextView) view.findViewById(android.R.id.text1);
-            tvText.setText(item.get("value"));
+            tvText.setText(item.getValue());
             return view;
         }
 
@@ -711,7 +711,7 @@ public abstract class OpacActivity extends AppCompatActivity {
                 return view;
             }
 
-            Map<String, String> item = objects.get(position);
+            T item = objects.get(position);
 
             if (contentView == null) {
                 LayoutInflater layoutInflater = (LayoutInflater) getContext()
@@ -722,7 +722,7 @@ public abstract class OpacActivity extends AppCompatActivity {
             }
 
             TextView tvText = (TextView) view.findViewById(android.R.id.text1);
-            tvText.setText(item.get("value"));
+            tvText.setText(item.getValue());
             return view;
         }
 

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/SearchFragment.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/SearchFragment.java
@@ -300,7 +300,7 @@ public class SearchFragment extends Fragment implements AccountSelectedListener 
                 TextView title = (TextView) v.findViewById(R.id.title);
                 title.setText(ddSearchField.getDisplayName());
                 Spinner spinner = (Spinner) v.findViewById(R.id.spinner);
-                spinner.setAdapter(((OpacActivity) getActivity()).new MetaAdapter(
+                spinner.setAdapter(((OpacActivity) getActivity()).new MetaAdapter<DropdownSearchField.Option>(
                         getActivity(), ddSearchField.getDropdownValues(),
                         R.layout.simple_spinner_item));
 
@@ -322,9 +322,9 @@ public class SearchFragment extends Fragment implements AccountSelectedListener 
                     }
                     if (!selection.equals("")) {
                         int j = 0;
-                        for (Map<String, String> row : ddSearchField
+                        for (DropdownSearchField.Option row : ddSearchField
                                 .getDropdownValues()) {
-                            if (row.get("key").equals(selection)) {
+                            if (row.getKey().equals(selection)) {
                                 spinner.setSelection(j);
                             }
                             j++;
@@ -542,7 +542,7 @@ public class SearchFragment extends Fragment implements AccountSelectedListener 
                     query.put(field.getId(),
                             ((DropdownSearchField) field).getDropdownValues()
                                                          .get(spinner.getSelectedItemPosition())
-                                                         .get("key"));
+                                                         .getKey());
                 }
             } else if (field instanceof CheckboxSearchField) {
                 CheckBox checkbox = (CheckBox) v.findViewById(R.id.checkbox);
@@ -581,7 +581,7 @@ public class SearchFragment extends Fragment implements AccountSelectedListener 
                 if (spinner.getSelectedItemPosition() != -1) {
                     String key = ((DropdownSearchField) field)
                             .getDropdownValues()
-                            .get(spinner.getSelectedItemPosition()).get("key");
+                            .get(spinner.getSelectedItemPosition()).getKey();
                     if (!key.equals("")) {
                         query.add(new SearchQuery(field, key));
                     }
@@ -610,7 +610,7 @@ public class SearchFragment extends Fragment implements AccountSelectedListener 
                 Spinner spinner = (Spinner) v.findViewById(R.id.spinner);
                 String homeBranch = ((DropdownSearchField) field)
                         .getDropdownValues()
-                        .get(spinner.getSelectedItemPosition()).get("key");
+                        .get(spinner.getSelectedItemPosition()).getKey();
                 if (!homeBranch.equals("")) {
                     sp.edit()
                       .putString(
@@ -646,9 +646,9 @@ public class SearchFragment extends Fragment implements AccountSelectedListener 
             } else if (field instanceof DropdownSearchField) {
                 Spinner spinner = (Spinner) v.findViewById(R.id.spinner);
                 int i = 0;
-                for (Map<String, String> map : ((DropdownSearchField) field)
+                for (DropdownSearchField.Option map : ((DropdownSearchField) field)
                         .getDropdownValues()) {
-                    if (map.get("key").equals(query.getString(field.getId()))) {
+                    if (map.getKey().equals(query.getString(field.getId()))) {
                         spinner.setSelection(i);
                         break;
                     }


### PR DESCRIPTION
This allows a more comprehensible and compact usage of the
DropdownSearchField. In addition, due to replacing many HashMap
instances by the simpler DropdownSearchField.Option object, the memory
footprint will be reduced.

After applying #337, the class `WebOpacAt` needs to be adapted …