### PR TITLE
Fix bug in PicaOld account view

### DIFF
--- a/opacclient/libopac/build.gradle
+++ b/opacclient/libopac/build.gradle
@@ -3,6 +3,8 @@ apply plugin: 'java'
 sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7
 
+[compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
+
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     // Use older org.json version to have an environment equivalent to the android platform

--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/PicaOld.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/PicaOld.java
@@ -530,14 +530,14 @@ public class PicaOld extends Pica {
                 media.add(e);
             }
         }
-        assert (media.size() == trs - 1);
+        assert (media.size() == trs);
     }
 
     static void parseResList(List<Map<String, String>> media, Document doc,
             StringProvider stringProvider) throws
             OpacErrorException {
 
-        Elements copytrs = doc.select("table[summary^=list] tr[valign=top]");
+        Elements copytrs = doc.select("table[summary^=list] > tbody >  tr[valign=top]");
 
         int trs = copytrs.size();
         if (trs < 1) {
@@ -594,7 +594,7 @@ public class PicaOld extends Pica {
 
             media.add(e);
         }
-        assert (media.size() == trs - 1);
+        assert (media.size() == trs);
     }
 
     private void updateLorReservations(Document doc) {

--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/PicaOld.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/PicaOld.java
@@ -277,8 +277,7 @@ public class PicaOld extends Pica {
         params.add(new BasicNameValuePair("BOR_PW_ENC", URLDecoder.decode(
                 pwEncoded, "UTF-8")));
         if (lor_reservations != null) {
-            params.add(new BasicNameValuePair("LOR_RESERVATIONS",
-                    lor_reservations));
+            params.add(new BasicNameValuePair("LOR_RESERVATIONS", lor_reservations));
         }
 
         params.add(new BasicNameValuePair("VB", media));
@@ -366,14 +365,16 @@ public class PicaOld extends Pica {
                 && !doc.select(".alert").text().contains("No outstanding loans")
                 && !doc.select(".alert").text().contains("Geen uitlening")
                 && !doc.select(".alert").text().contains("Aucun emprunt")) {
-            parse_medialist(media, doc);
+            List<String> renewalCounts = loadRenewalCounts(doc);
+            parseMediaList(media, doc, stringProvider, renewalCounts);
         }
         if (doc2.select("table[summary^=list]").size() > 0
                 && !doc2.select(".alert").text().contains("Keine Vormerkungen")
                 && !doc2.select(".alert").text().contains("No outstanding reservations")
                 && !doc2.select(".alert").text().contains("Geen reservering")
                 && !doc2.select(".alert").text().contains("Aucune réservation")) {
-            parse_reslist(reserved, doc2);
+            updateLorReservations(doc);
+            parseResList(reserved, doc2, stringProvider);
         }
 
         res.setLent(media);
@@ -383,8 +384,21 @@ public class PicaOld extends Pica {
 
     }
 
-    protected void parse_medialist(List<Map<String, String>> media, Document doc)
-            throws OpacErrorException {
+    private List<String> loadRenewalCounts(Document doc) {
+        List<String> renewalCounts = new ArrayList<>();
+        for (Element iframe : doc.select("iframe[name=nr_renewals_in_a_box]")) {
+            try {
+                String html = httpGet(iframe.attr("src"), getDefaultEncoding());
+                renewalCounts.add(Jsoup.parse(html).text());
+            } catch (IOException e) {
+                renewalCounts.add(null);
+            }
+        }
+        return renewalCounts;
+    }
+
+    static void parseMediaList(List<Map<String, String>> media, Document doc,
+            StringProvider stringProvider, List<String> renewalCounts) throws OpacErrorException {
 
         Elements copytrs = doc
                 .select("table[summary^=list] > tbody > tr[valign=top]");
@@ -459,15 +473,8 @@ public class PicaOld extends Pica {
                 media.add(e);
             } else { // like in Kiel
                 String prolongCount = "";
-                if (tr.select("iframe[name=nr_renewals_in_a_box]").size() > 0) {
-                    try {
-                        String html = httpGet(
-                                tr.select("iframe[name=nr_renewals_in_a_box]")
-                                  .attr("src"), getDefaultEncoding());
-                        prolongCount = Jsoup.parse(html).text();
-                    } catch (IOException e) {
-
-                    }
+                if (renewalCounts.size() == trs && renewalCounts.get(i) != null) {
+                    prolongCount = renewalCounts.get(i);
                 }
                 String reminderCount = tr.child(13).text().trim();
                 if (reminderCount.contains(" Mahn")
@@ -526,13 +533,9 @@ public class PicaOld extends Pica {
         assert (media.size() == trs - 1);
     }
 
-    protected void parse_reslist(List<Map<String, String>> media, Document doc) throws
+    static void parseResList(List<Map<String, String>> media, Document doc,
+            StringProvider stringProvider) throws
             OpacErrorException {
-
-        if (doc.select("input[name=LOR_RESERVATIONS]").size() > 0) {
-            lor_reservations = doc.select("input[name=LOR_RESERVATIONS]").attr(
-                    "value");
-        }
 
         Elements copytrs = doc.select("table[summary^=list] tr[valign=top]");
 
@@ -592,6 +595,12 @@ public class PicaOld extends Pica {
             media.add(e);
         }
         assert (media.size() == trs - 1);
+    }
+
+    private void updateLorReservations(Document doc) {
+        if (doc.select("input[name=LOR_RESERVATIONS]").size() > 0) {
+            lor_reservations = doc.select("input[name=LOR_RESERVATIONS]").attr("value");
+        }
     }
 
 

--- a/opacclient/libopac/src/test/java/de/geeksfactory/opacclient/apis/BaseTest.java
+++ b/opacclient/libopac/src/test/java/de/geeksfactory/opacclient/apis/BaseTest.java
@@ -1,0 +1,49 @@
+package de.geeksfactory.opacclient.apis;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
+
+public class BaseTest {
+    /**
+     * Reads content from an InputStream into a string
+     *
+     * @param is InputStream to read from
+     * @return String content of the InputStream
+     */
+    private static String convertStreamToString(InputStream is) throws IOException {
+        BufferedReader reader;
+        try {
+            reader = new BufferedReader(new InputStreamReader(is, "UTF-8"));
+        } catch (UnsupportedEncodingException e1) {
+            reader = new BufferedReader(new InputStreamReader(is));
+        }
+        StringBuilder sb = new StringBuilder();
+
+        String line;
+        try {
+            while ((line = reader.readLine()) != null) {
+                sb.append(line).append("\n");
+            }
+        } finally {
+            try {
+                is.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        return sb.toString();
+    }
+
+    protected String readResource(String filename) {
+        InputStream is = getClass().getResourceAsStream(filename);
+        try {
+            return convertStreamToString(is);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+}

--- a/opacclient/libopac/src/test/java/de/geeksfactory/opacclient/apis/PicaOldTest.java
+++ b/opacclient/libopac/src/test/java/de/geeksfactory/opacclient/apis/PicaOldTest.java
@@ -1,0 +1,15 @@
+package de.geeksfactory.opacclient.apis;
+
+import org.junit.Test;
+
+public class PicaOldTest {
+    @Test
+    public void testParseMediaList() {
+
+    }
+
+    @Test
+    public void testParseResList() {
+
+    }
+}

--- a/opacclient/libopac/src/test/java/de/geeksfactory/opacclient/apis/PicaOldTest.java
+++ b/opacclient/libopac/src/test/java/de/geeksfactory/opacclient/apis/PicaOldTest.java
@@ -1,15 +1,27 @@
 package de.geeksfactory.opacclient.apis;
 
+import org.jsoup.Jsoup;
 import org.junit.Test;
 
-public class PicaOldTest {
-    @Test
-    public void testParseMediaList() {
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
+import de.geeksfactory.opacclient.i18n.DummyStringProvider;
+
+public class PicaOldTest extends BaseTest {
+    @Test
+    public void testParseMediaList() throws OpacApi.OpacErrorException {
+        String html = readResource("/pica_old/medialist/marburg.html");
+        List<Map<String, String>> media = new ArrayList<>();
+        PicaOld.parseMediaList(media, Jsoup.parse(html), new DummyStringProvider(),
+                new ArrayList<String>());
     }
 
     @Test
-    public void testParseResList() {
-
+    public void testParseResList() throws OpacApi.OpacErrorException {
+        String html = readResource("/pica_old/reslist/marburg.html");
+        List<Map<String, String>> media = new ArrayList<>();
+        PicaOld.parseResList(media, Jsoup.parse(html), new DummyStringProvider());
     }
 }

--- a/opacclient/libopac/src/test/resources/pica_old/medialist/marburg.html
+++ b/opacclient/libopac/src/test/resources/pica_old/medialist/marburg.html
@@ -1,0 +1,710 @@
+<HTML>
+<HEAD>
+    <TITLE>OPC4 - borrower/listofloans</TITLE>
+
+
+    <SCRIPT language=JavaScript>
+<!--
+b=navigator.appName;
+v=parseInt(navigator.appVersion);
+function f(url, names){
+    if ((b="Netscape"&&v=="3")||(v>="4")) document[names].src=url;
+}
+function __keydown() {
+    k=event.keyCode;
+    if(k==113) { x=document.all["TRM"]; if(x) x.focus(); }
+}
+// -->
+
+    </SCRIPT>
+
+    <SCRIPT LANGUAGE="JavaScript">
+<!--
+pu="";
+popup="";
+function PU(URL,w,h) {
+    if (v>="3") {
+        WINDOW='width='+w+',height='+h+',scrollbars=1,resizable=1,status=0'; popup=window.open(URL,"_blank",WINDOW);
+        if (pu!=popup) {
+            pu=popup;
+        }
+    } else {
+        window.location.href=URL;
+    }
+}// Copyright Pica 1999 (RonH)
+//-->
+
+    </SCRIPT>
+
+
+    <BASE HREF="https://opac.ub.uni-marburg.de/DB=1/">
+    <LINK REL=STYLESHEET href="https://opac.ub.uni-marburg.de/STYLESHEET">
+    <META http-equiv="Refresh"
+          content="1500;
+	  URL=TIMEOUT?CWIN=Y&REFERER=&REFRTIME=-1&REFRURL=EXIT%3FREFRTIME%3D-1%26DEST%3D%252F">
+</HEAD>
+<BODY marginwidth="0" marginheight="0"
+
+      style="background-image:url(); background-repeat:repeat-x;"
+        >
+
+<table summary="Main layout" width="100%"
+       cellpadding="0" cellspacing="0" border="0">
+    <tr>
+
+
+        <td class="lng" height="20" width="120">
+            <center>
+                <table summary="Language switch"
+                       cellpadding="0" cellspacing="0" border="0">
+                    <tr>
+                        <td width="4"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="4"
+                                height="1"
+                                border="0"></td>
+
+                    </tr>
+                </table>
+            </center>
+        </td>
+        <td bgcolor="#EEEBDD" width="1"><img
+                alt=""
+                src="/img_psi/2.0/gui/white.gif"
+                width="1"
+                height="20"
+                border="0"></td>
+        <td class="nav" width="100%">
+            <table summary="Navigation bar" width="100%"
+                   border="0" cellpadding="0" cellspacing="0">
+                <tr>
+                    <td width="35"><img
+                            alt=""
+                            src="/img_psi/2.0/gui/empty.gif"
+                            width="35"
+                            height="20"
+                            border="0"></td>
+
+                    <td class="copy" align="right" width="100%" nowrap><a
+                            target="_blank"
+                            href="http://oclcpica.org/?id=2&ln=de"
+                            title="opc4 v2.8.3.8"
+                            class="copy">OPC4 v2.8.3.8&nbsp;&copy;&nbsp;1998-2015&nbsp;OCLC&nbsp;PICA</a>
+                    </td>
+                    <td width="10"
+                        bgcolor="#EEEBDD"><img
+                            alt=""
+                            src="/img_psi/2.0/gui/empty.gif"
+                            width="10"
+                            height="1"
+                            border="0"></td>
+                </tr>
+            </table>
+        </td>
+
+    </tr>
+
+    <tr>
+        <td height="1"><img
+                alt=""
+                src="/img_psi/2.0/gui/white.gif"
+                width="120"
+                height="1"
+                border="0"></td>
+    </tr>
+
+    <tr>
+
+        <td height="90" align="center" bgcolor="white"><img
+
+                src="/img_psi/2.0/logos/mar_philip.svg"
+                alt=""
+                height="90" width="160" border="0">
+            <!-- JS height="90" width="120" --></td>
+        <td bgcolor="white"><img
+                alt=""
+                src="/img_psi/2.0/gui/white.gif"
+                width="1"
+                height="90"
+                border="0"></td>
+        <td class="cmd">
+            <table summary="safety warning"
+                   cellpadding="0" cellspacing="0" border="0" width="100%">
+                <tr>
+                    <td><img
+                            alt=""
+                            src="/img_psi/2.0/gui/empty.gif"
+                            width="35"
+                            height="90"
+                            border="0"></td>
+                    <td width="100%" align="left"><strong
+                            class="alert">Zum Schutz Ihrer Daten sollten Sie dieses Fenster nach Benutzung schlie&szlig;en!</strong>
+                    </td>
+                </tr>
+            </table>
+        </td>
+        <!-- /td moved one line up [MM] -->
+    </tr>
+
+    <tr>
+        <td height="1"><img
+                alt=""
+                src="/img_psi/2.0/gui/white.gif"
+                width="120"
+                height="1"
+                border="0"></td>
+    </tr>
+
+    <tr>
+
+        <td height="20" bgcolor="#134063"><img
+                alt=""
+                src="/img_psi/2.0/gui/empty.gif"
+                width="1"
+                height="1"
+                border="0"></td>
+        <td bgcolor="#134063"><img
+                src="/img_psi/2.0/gui/white.gif" alt="" width="1" height="20"></td>
+        <td colspan="1"
+            bgcolor="#134063" align="center" nowrap>
+            <center>
+                <table summary="Tab bar"
+                       cellpadding="0" cellspacing="0" border="0">
+                    <tr>
+                        <td bgcolor="#134063"
+                            height="1" colspan="5"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                        <td bgcolor="#134063"
+                            height="1" colspan="5"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                        <td bgcolor="#134063"
+                            height="1" colspan="5"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                        <td bgcolor="#134063"
+                            height="1" colspan="5"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                        <td bgcolor="#134063"
+                            height="1" colspan="5"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                    </tr>
+                    <tr>
+                        <td width="1"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                        <td class="tabbar" nowrap><img
+                                alt=""
+                                src="/img_psi/2.0/gui/mar_tableft.gif"
+                                width="11" height="18"></td>
+
+                        <td class="tab0" height="18"><a class="tab0"
+                                                        href="/loan/DB=1/USERINFO?ACT=UI_DATA&BOR_U=********&BOR_PW_ENC=********">Benutzerdaten</a>
+                        </td>
+
+                        <td class="tabbar" nowrap><img
+                                alt=""
+                                src="/img_psi/2.0/gui/mar_tabright.gif"
+                                width="11" height="18"></td>
+                        <td width="1"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                        <td width="1"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                        <td class="tabbar" nowrap><img
+                                alt=""
+                                src="/img_psi/2.0/gui/mar_tableft.gif"
+                                width="11" height="18"></td>
+
+                        <td class="tab1" height="18">Entleihungen</td>
+
+                        <td class="tabbar" nowrap><img
+                                alt=""
+                                src="/img_psi/2.0/gui/mar_tabright.gif"
+                                width="11" height="18"></td>
+                        <td width="1"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                        <td width="1"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                        <td class="tabbar" nowrap><img
+                                alt=""
+                                src="/img_psi/2.0/gui/mar_tableft.gif"
+                                width="11" height="18"></td>
+
+                        <td class="tab0" height="18"><a class="tab0"
+                                                        href="/loan/DB=1/USERINFO?ACT=UI_LOR&BOR_U=********&BOR_PW_ENC=********">Vormerkungen</a>
+                        </td>
+
+                        <td class="tabbar" nowrap><img
+                                alt=""
+                                src="/img_psi/2.0/gui/mar_tabright.gif"
+                                width="11" height="18"></td>
+                        <td width="1"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                        <td width="1"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                        <td class="tabbar" nowrap><img
+                                alt=""
+                                src="/img_psi/2.0/gui/mar_tableft.gif"
+                                width="11" height="18"></td>
+
+                        <td class="tab0" height="18"><a class="tab0"
+                                                        href="/loan/DB=1/USERINFO?ACT=UI_LOC&BOR_U=********&BOR_PW_ENC=********">Kosten</a>
+                        </td>
+
+                        <td class="tabbar" nowrap><img
+                                alt=""
+                                src="/img_psi/2.0/gui/mar_tabright.gif"
+                                width="11" height="18"></td>
+                        <td width="1"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                        <td width="1"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                        <td class="tabbar" nowrap><img
+                                alt=""
+                                src="/img_psi/2.0/gui/mar_tableft.gif"
+                                width="11" height="18"></td>
+
+                        <td class="tab0" height="18"><a class="tab0"
+                                                        href="/loan/DB=1/USERINFO?ACT=UI_CHUPW&BOR_U=********&BOR_PW_ENC=********">Passwort</a>
+                        </td>
+
+                        <td class="tabbar" nowrap><img
+                                alt=""
+                                src="/img_psi/2.0/gui/mar_tabright.gif"
+                                width="11" height="18"></td>
+                        <td width="1"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                    </tr>
+                    <tr>
+                        <td bgcolor="#134063"
+                            height="1" colspan="5"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+
+                        <td width="1"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                        <td bgcolor="white"
+                            height="1" colspan="3"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                        <td width="1"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+
+                        <td bgcolor="#134063"
+                            height="1" colspan="5"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+
+                        <td bgcolor="#134063"
+                            height="1" colspan="5"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+
+                        <td bgcolor="#134063"
+                            height="1" colspan="5"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+
+                        <td><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                    </tr>
+                </table>
+            </center>
+        </td>
+    </tr>
+
+    <tr>
+        <td height="1"><img
+                alt=""
+                src="/img_psi/2.0/gui/white.gif"
+                width="120"
+                height="1"
+                border="0"></td>
+    </tr>
+
+    <tr>
+
+        <td class="mnu" valign="top">
+            <table summary="Menu layout" width="100%"
+                   border="0" cellpadding="0" cellspacing="0">
+
+
+                <SCRIPT type="text/javascript" language="javascript">
+document.write('<TR><TD class="mnu"><p class="mnu"><a class="mnu" href="javascript:window.close()"><IMG name=closewindow src="/img_psi/2.0/logos/b_closewindow_on_du.gif" alt="" width=130 height=120 hspace=0 vspace=0 border=1></A><br><hr></TD></TR>');
+
+                </SCRIPT>
+                <NOSCRIPT>
+
+                </NOSCRIPT>
+
+
+                <tr>
+                    <td><img
+                            alt=""
+                            src="/img_psi/2.0/gui/empty.gif"
+                            width="1"
+                            height="300"
+                            border="0"></td>
+                </tr>
+            </table>
+        </td>
+        <td><img
+                alt=""
+                src="/img_psi/2.0/gui/empty.gif"
+                width="1"
+                height="1"
+                border="0"></td>
+        <td colspan="1"
+            class="cnt" valign="top">
+            <form method="post" action="https://opac.ub.uni-marburg.de/loan/DB=1/USERINFO"
+                  name="LoanRenewalForm">
+                <input type="hidden" name="ACT" value="UI_RENEWLOAN">
+                <input type="hidden" name="BOR_U" value="********">
+                <input type="hidden" name="BOR_PW_ENC" value="********">
+                <table summary="User data header" width="100%" cellpadding="0" cellspacing="0"
+                       border="0">
+                    <tr>
+                        <td class="h2" valign="top"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="16"
+                                border="0"></td>
+                    </tr>
+                    <tr>
+                        <td valign="top"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="12"
+                                height="1"
+                                border="0"><img alt="*" src="/img_psi/2.0/gui/h2.gif" width="19"
+                                                height="12" border="0"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="4"
+                                height="1"
+                                border="0"></td>
+                        <td valign="top" width="100%"><strong class="h2">Entleihungen</strong><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="10"
+                                height="1"
+                                border="0"><span class="subtitle"></span></td>
+                        <td><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="10"
+                                height="1"
+                                border="0"></td>
+                    </tr>
+                    <tr>
+                        <td class="h2" valign="top"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="7"
+                                border="0"></td>
+                    </tr>
+                </table>
+
+                <table summary="body separator" width="100%" cellpadding="0" cellspacing="0"
+                       border="0">
+
+                    <TR>
+                        <TD><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="10"
+                                border="0"></TD>
+                    </TR>
+                    <TR>
+                        <TD class="bodysep" colspan="2"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></TD>
+                    </TR>
+                    <TR>
+                        <TD><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="10"
+                                border="0"></TD>
+                    </TR>
+                </table>
+                <table summary="loans renewal - text block" width="100%" cellpadding="0"
+                       cellspacing="0" border="0">
+                    <tr>
+                        <td><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="35"
+                                height="1"
+                                border="0"></td>
+                        <td>
+                            <table summary="Identification - no authorization" width="100%"
+                                   cellpadding="0" cellspacing="0" border="0">
+                                <tr>
+                                    <td><input class="button" type="submit" value="verl&auml;ngern">
+                                    </td>
+                                    <td><img
+                                            alt=""
+                                            src="/img_psi/2.0/gui/empty.gif"
+                                            width="15"
+                                            height="1"
+                                            border="0"></td>
+                                    <td width="100%" class="regular-text"
+                                        nowrap>Bitte klicken Sie auf
+                                        <strong>verl&auml;ngern</strong>, um die ausgew&auml;hlten Ausleihen zu verl&auml;ngern.
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                        <td width="100%"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="10"
+                                height="1"
+                                border="0"></td>
+                    </tr>
+                    <tr>
+                        <td valign="top"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="14"
+                                border="0"></td>
+                    </tr>
+                </table>
+                <table summary="list of loans - data" width="100%" cellpadding="0" cellspacing="0"
+                       border="0">
+                    <tr>
+                        <td class="infotab"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="35"
+                                height="20"
+                                border="0"></td>
+                        <td><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                        <td class="infotab"><img
+                                src="/img_psi/2.0/gui/checkon.gif"
+                                alt=""
+                                height="20"
+                                width="20"
+                                border="0">
+                        <td>
+                        <td><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                        <td class="infotab"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="3"
+                                height="20"
+                                border="0"></td>
+                        <td class="infotab" width="100%" colspan="2">Titel
+                        <td>
+                    </tr>
+                    <tr>
+                        <td class="h2" valign="top"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="12"
+                                border="0"></td>
+                    </tr>
+
+
+                    <tr valign="top">
+                        <td><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="35"
+                                height="1"
+                                border="0"></td>
+                        <td></td>
+                        <td align="middle"><input type="checkbox"
+                                                  name="VB" value="12345678"></td>
+                        <td></td>
+                        <td></td>
+                        <td></td>
+                        <td class="plain" align="right">1.<img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="5"
+                                height="1"
+                                border="0"></td>
+                        <td width="100%">
+                            <table summary="title data" width="100%" cellpadding="0" cellspacing="0"
+                                   border="0">
+                                <tr valign="top">
+                                    <td class="plain">Titel des ersten Buches</td>
+                                </tr>
+                                <tr valign="top" style="padding-bottom:4px;" nowrap>
+                                    <td class="value-small"><span
+                                            class="label-small">Signatur:</span> asdf; <span
+                                            class="label-small">Status:</span> beim Nutzer (0 Mahnung(en));
+                                        <span class="label-small">Leihfristende:</span> 04-12-2015;
+                                        <span class="label-small">Vormerkungen:</span> 0
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                    <tr valign="top">
+                        <td><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="35"
+                                height="1"
+                                border="0"></td>
+                        <td></td>
+                        <td align="middle"><input type="checkbox"
+                                                  name="VB" value="12345678"></td>
+                        <td></td>
+                        <td></td>
+                        <td></td>
+                        <td class="plain" align="right">2.<img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="5"
+                                height="1"
+                                border="0"></td>
+                        <td width="100%">
+                            <table summary="title data" width="100%" cellpadding="0" cellspacing="0"
+                                   border="0">
+                                <tr valign="top">
+                                    <td class="plain">Titel des zweiten Buches</td>
+                                </tr>
+                                <tr valign="top" style="padding-bottom:4px;" nowrap>
+                                    <td class="value-small"><span
+                                            class="label-small">Signatur:</span> hjkl; <span
+                                            class="label-small">Status:</span> beim Nutzer (0 Mahnung(en));
+                                        <span class="label-small">Leihfristende:</span> 04-12-2015;
+                                        <span class="label-small">Vormerkungen:</span> 0
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+
+                </table>
+            </form>
+        </td>
+    </tr>
+    <TR>
+        <TD><img
+                alt=""
+                src="/img_psi/2.0/gui/empty.gif"
+                width="1"
+                height="20"
+                border="0"></TD>
+    </TR>
+</table>
+
+
+<script type="text/javascript"
+        src="https://recommender.bibtip.de/js/bibtip_ub_mr.js"></script>
+
+
+<img src="https://dbspixel.hbz-nrw.de/count?id=AH004&amp;page=2" width="1" heigh
+     t="1">
+
+</BODY>
+</HTML>

--- a/opacclient/libopac/src/test/resources/pica_old/reslist/marburg.html
+++ b/opacclient/libopac/src/test/resources/pica_old/reslist/marburg.html
@@ -1,0 +1,672 @@
+<HTML>
+<HEAD>
+    <TITLE>OPC4 - borrower/listofreservations</TITLE>
+
+
+    <SCRIPT language=JavaScript>
+<!--
+b=navigator.appName;
+v=parseInt(navigator.appVersion);
+function f(url, names){
+    if ((b="Netscape"&&v=="3")||(v>="4")) document[names].src=url;
+}
+function __keydown() {
+    k=event.keyCode;
+    if(k==113) { x=document.all["TRM"]; if(x) x.focus(); }
+}
+// -->
+
+    </SCRIPT>
+
+    <SCRIPT LANGUAGE="JavaScript">
+<!--
+pu="";
+popup="";
+function PU(URL,w,h) {
+    if (v>="3") {
+        WINDOW='width='+w+',height='+h+',scrollbars=1,resizable=1,status=0'; popup=window.open(URL,"_blank",WINDOW);
+        if (pu!=popup) {
+            pu=popup;
+        }
+    } else {
+        window.location.href=URL;
+    }
+}// Copyright Pica 1999 (RonH)
+//-->
+
+    </SCRIPT>
+
+
+    <BASE HREF="https://opac.ub.uni-marburg.de/DB=1/">
+    <LINK REL=STYLESHEET href="https://opac.ub.uni-marburg.de/STYLESHEET">
+    <META http-equiv="Refresh"
+          content="1500;
+	  URL=TIMEOUT?CWIN=Y&REFERER=&REFRTIME=-1&REFRURL=EXIT%3FREFRTIME%3D-1%26DEST%3D%252F">
+</HEAD>
+<BODY marginwidth="0" marginheight="0"
+
+      style="background-image:url(); background-repeat:repeat-x;"
+        >
+
+<table summary="Main layout" width="100%"
+       cellpadding="0" cellspacing="0" border="0">
+    <tr>
+
+
+        <td class="lng" height="20" width="120">
+            <center>
+                <table summary="Language switch"
+                       cellpadding="0" cellspacing="0" border="0">
+                    <tr>
+                        <td width="4"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="4"
+                                height="1"
+                                border="0"></td>
+
+                    </tr>
+                </table>
+            </center>
+        </td>
+        <td bgcolor="#EEEBDD" width="1"><img
+                alt=""
+                src="/img_psi/2.0/gui/white.gif"
+                width="1"
+                height="20"
+                border="0"></td>
+        <td class="nav" width="100%">
+            <table summary="Navigation bar" width="100%"
+                   border="0" cellpadding="0" cellspacing="0">
+                <tr>
+                    <td width="35"><img
+                            alt=""
+                            src="/img_psi/2.0/gui/empty.gif"
+                            width="35"
+                            height="20"
+                            border="0"></td>
+
+                    <td class="copy" align="right" width="100%" nowrap><a
+                            target="_blank"
+                            href="http://oclcpica.org/?id=2&ln=de"
+                            title="opc4 v2.8.3.8"
+                            class="copy">OPC4 v2.8.3.8&nbsp;&copy;&nbsp;1998-2015&nbsp;OCLC&nbsp;PICA</a>
+                    </td>
+                    <td width="10"
+                        bgcolor="#EEEBDD"><img
+                            alt=""
+                            src="/img_psi/2.0/gui/empty.gif"
+                            width="10"
+                            height="1"
+                            border="0"></td>
+                </tr>
+            </table>
+        </td>
+
+    </tr>
+
+    <tr>
+        <td height="1"><img
+                alt=""
+                src="/img_psi/2.0/gui/white.gif"
+                width="120"
+                height="1"
+                border="0"></td>
+    </tr>
+
+    <tr>
+
+        <td height="90" align="center" bgcolor="white"><img
+
+                src="/img_psi/2.0/logos/mar_philip.svg"
+                alt=""
+                height="90" width="160" border="0">
+            <!-- JS height="90" width="120" --></td>
+        <td bgcolor="white"><img
+                alt=""
+                src="/img_psi/2.0/gui/white.gif"
+                width="1"
+                height="90"
+                border="0"></td>
+        <td class="cmd">
+            <table summary="safety warning"
+                   cellpadding="0" cellspacing="0" border="0" width="100%">
+                <tr>
+                    <td><img
+                            alt=""
+                            src="/img_psi/2.0/gui/empty.gif"
+                            width="35"
+                            height="90"
+                            border="0"></td>
+                    <td width="100%" align="left"><strong
+                            class="alert">Zum Schutz Ihrer Daten sollten Sie dieses Fenster nach Benutzung schlie&szlig;en!</strong>
+                    </td>
+                </tr>
+            </table>
+        </td>
+        <!-- /td moved one line up [MM] -->
+    </tr>
+
+    <tr>
+        <td height="1"><img
+                alt=""
+                src="/img_psi/2.0/gui/white.gif"
+                width="120"
+                height="1"
+                border="0"></td>
+    </tr>
+
+    <tr>
+
+        <td height="20" bgcolor="#134063"><img
+                alt=""
+                src="/img_psi/2.0/gui/empty.gif"
+                width="1"
+                height="1"
+                border="0"></td>
+        <td bgcolor="#134063"><img
+                src="/img_psi/2.0/gui/white.gif" alt="" width="1" height="20"></td>
+        <td colspan="1"
+            bgcolor="#134063" align="center" nowrap>
+            <center>
+                <table summary="Tab bar"
+                       cellpadding="0" cellspacing="0" border="0">
+                    <tr>
+                        <td bgcolor="#134063"
+                            height="1" colspan="5"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                        <td bgcolor="#134063"
+                            height="1" colspan="5"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                        <td bgcolor="#134063"
+                            height="1" colspan="5"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                        <td bgcolor="#134063"
+                            height="1" colspan="5"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                        <td bgcolor="#134063"
+                            height="1" colspan="5"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                    </tr>
+                    <tr>
+                        <td width="1"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                        <td class="tabbar" nowrap><img
+                                alt=""
+                                src="/img_psi/2.0/gui/mar_tableft.gif"
+                                width="11" height="18"></td>
+
+                        <td class="tab0" height="18"><a class="tab0"
+                                                        href="/loan/DB=1/USERINFO?ACT=UI_DATA&BOR_U=********&BOR_PW_ENC=********">Benutzerdaten</a>
+                        </td>
+
+                        <td class="tabbar" nowrap><img
+                                alt=""
+                                src="/img_psi/2.0/gui/mar_tabright.gif"
+                                width="11" height="18"></td>
+                        <td width="1"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                        <td width="1"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                        <td class="tabbar" nowrap><img
+                                alt=""
+                                src="/img_psi/2.0/gui/mar_tableft.gif"
+                                width="11" height="18"></td>
+
+                        <td class="tab0" height="18"><a class="tab0"
+                                                        href="/loan/DB=1/USERINFO?ACT=UI_LOL&BOR_U=********&BOR_PW_ENC=********">Entleihungen</a>
+                        </td>
+
+                        <td class="tabbar" nowrap><img
+                                alt=""
+                                src="/img_psi/2.0/gui/mar_tabright.gif"
+                                width="11" height="18"></td>
+                        <td width="1"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                        <td width="1"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                        <td class="tabbar" nowrap><img
+                                alt=""
+                                src="/img_psi/2.0/gui/mar_tableft.gif"
+                                width="11" height="18"></td>
+
+                        <td class="tab1" height="18">Vormerkungen</td>
+
+                        <td class="tabbar" nowrap><img
+                                alt=""
+                                src="/img_psi/2.0/gui/mar_tabright.gif"
+                                width="11" height="18"></td>
+                        <td width="1"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                        <td width="1"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                        <td class="tabbar" nowrap><img
+                                alt=""
+                                src="/img_psi/2.0/gui/mar_tableft.gif"
+                                width="11" height="18"></td>
+
+                        <td class="tab0" height="18"><a class="tab0"
+                                                        href="/loan/DB=1/USERINFO?ACT=UI_LOC&BOR_U=********&BOR_PW_ENC=********">Kosten</a>
+                        </td>
+
+                        <td class="tabbar" nowrap><img
+                                alt=""
+                                src="/img_psi/2.0/gui/mar_tabright.gif"
+                                width="11" height="18"></td>
+                        <td width="1"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                        <td width="1"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                        <td class="tabbar" nowrap><img
+                                alt=""
+                                src="/img_psi/2.0/gui/mar_tableft.gif"
+                                width="11" height="18"></td>
+
+                        <td class="tab0" height="18"><a class="tab0"
+                                                        href="/loan/DB=1/USERINFO?ACT=UI_CHUPW&BOR_U=********&BOR_PW_ENC=********">Passwort</a>
+                        </td>
+
+                        <td class="tabbar" nowrap><img
+                                alt=""
+                                src="/img_psi/2.0/gui/mar_tabright.gif"
+                                width="11" height="18"></td>
+                        <td width="1"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                    </tr>
+                    <tr>
+                        <td bgcolor="#134063"
+                            height="1" colspan="5"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+
+                        <td bgcolor="#134063"
+                            height="1" colspan="5"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+
+                        <td width="1"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                        <td bgcolor="white"
+                            height="1" colspan="3"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                        <td width="1"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+
+                        <td bgcolor="#134063"
+                            height="1" colspan="5"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+
+                        <td bgcolor="#134063"
+                            height="1" colspan="5"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+
+                        <td><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                    </tr>
+                </table>
+            </center>
+        </td>
+    </tr>
+
+    <tr>
+        <td height="1"><img
+                alt=""
+                src="/img_psi/2.0/gui/white.gif"
+                width="120"
+                height="1"
+                border="0"></td>
+    </tr>
+
+    <tr>
+
+        <td class="mnu" valign="top">
+            <table summary="Menu layout" width="100%"
+                   border="0" cellpadding="0" cellspacing="0">
+
+
+                <SCRIPT type="text/javascript" language="javascript">
+document.write('<TR><TD class="mnu"><p class="mnu"><a class="mnu" href="javascript:window.close()"><IMG name=closewindow src="/img_psi/2.0/logos/b_closewindow_on_du.gif" alt="" width=130 height=120 hspace=0 vspace=0 border=1></A><br><hr></TD></TR>');
+
+                </SCRIPT>
+                <NOSCRIPT>
+
+                </NOSCRIPT>
+
+
+                <tr>
+                    <td><img
+                            alt=""
+                            src="/img_psi/2.0/gui/empty.gif"
+                            width="1"
+                            height="300"
+                            border="0"></td>
+                </tr>
+            </table>
+        </td>
+        <td><img
+                alt=""
+                src="/img_psi/2.0/gui/empty.gif"
+                width="1"
+                height="1"
+                border="0"></td>
+        <td colspan="1"
+            class="cnt" valign="top">
+            <form method="post" action="https://opac.ub.uni-marburg.de/loan/DB=1/USERINFO"
+                  name="ReservationsCancelForm">
+                <input type="hidden" name="ACT" value="UI_CANCELRES">
+                <input type="hidden" name="BOR_U" value="********">
+                <input type="hidden" name="BOR_PW_ENC" value="********">
+                <input type="hidden" name="LOR_RESERVATIONS"
+                       value="12345678TitelDesBuches13-11-20152asdf">
+                <table summary="User data header" width="100%" cellpadding="0" cellspacing="0"
+                       border="0">
+                    <tr>
+                        <td class="h2" valign="top"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="16"
+                                border="0"></td>
+                    </tr>
+                    <tr>
+                        <td valign="top"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="12"
+                                height="1"
+                                border="0"><img alt="*" src="/img_psi/2.0/gui/h2.gif" width="19"
+                                                height="12" border="0"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="4"
+                                height="1"
+                                border="0"></td>
+                        <td valign="top" width="100%"><strong class="h2">Vormerkungen</strong><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="10"
+                                height="1"
+                                border="0"><span class="subtitle"></span></td>
+                        <td><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="10"
+                                height="1"
+                                border="0"></td>
+                    </tr>
+                    <tr>
+                        <td class="h2" valign="top"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="7"
+                                border="0"></td>
+                    </tr>
+                </table>
+
+                <table summary="body separator" width="100%" cellpadding="0" cellspacing="0"
+                       border="0">
+
+                    <TR>
+                        <TD><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="10"
+                                border="0"></TD>
+                    </TR>
+                    <TR>
+                        <TD class="bodysep" colspan="2"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></TD>
+                    </TR>
+                    <TR>
+                        <TD><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="10"
+                                border="0"></TD>
+                    </TR>
+                </table>
+                <table summary="cancel reservations - text block" width="100%" cellpadding="0"
+                       cellspacing="0" border="0">
+                    <tr>
+                        <td><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="35"
+                                height="1"
+                                border="0"></td>
+                        <td>
+                            <table summary="Identification - no authorization" width="100%"
+                                   cellpadding="0" cellspacing="0" border="0">
+                                <tr>
+                                    <td><input class="button" type="submit" value="l&ouml;schen">
+                                    </td>
+                                    <td><img
+                                            alt=""
+                                            src="/img_psi/2.0/gui/empty.gif"
+                                            width="15"
+                                            height="1"
+                                            border="0"></td>
+                                    <td width="100%" class="regular-text"
+                                        nowrap>Bitte klicken Sie auf
+                                        <strong>l&ouml;schen</strong>, um die ausgew&auml;hlten Vormerkungen r&uuml;ckg&auml;ngig zu machen.
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                        <td width="100%"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="10"
+                                height="1"
+                                border="0"></td>
+                    </tr>
+                    <tr>
+                        <td valign="top"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="14"
+                                border="0"></td>
+                    </tr>
+                </table>
+                <table summary="list of reservations - data" width="100%" cellpadding="0"
+                       cellspacing="0" border="0">
+                    <tr>
+                        <td class="infotab"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="35"
+                                height="20"
+                                border="0"></td>
+                        <td><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                        <td class="infotab"><img
+                                src="/img_psi/2.0/gui/checkon.gif"
+                                alt=""
+                                height="20"
+                                width="20"
+                                border="0">
+                        <td>
+                        <td><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="1"
+                                border="0"></td>
+                        <td class="infotab"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="3"
+                                height="20"
+                                border="0"></td>
+                        <td class="infotab" width="100%" colspan="2">Titel
+                        <td>
+                    </tr>
+                    <tr>
+                        <td class="h2" valign="top"><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="1"
+                                height="12"
+                                border="0"></td>
+                    </tr>
+
+
+                    <tr valign="top">
+                        <td><img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="35"
+                                height="1"
+                                border="0"></td>
+                        <td></td>
+                        <td align="middle"><input type="checkbox"
+                                                  name="VB" value="11335284"></td>
+                        <td></td>
+                        <td></td>
+                        <td class="plain" align="right">1.<img
+                                alt=""
+                                src="/img_psi/2.0/gui/empty.gif"
+                                width="5"
+                                height="1"
+                                border="0"></td>
+                        <td width="100%">
+                            <table summary="title data" width="100%" cellpadding="0" cellspacing="0"
+                                   border="0">
+                                <tr valign="top">
+                                    <td class="plain">TitelDesBuches</td>
+                                </tr>
+                                <tr valign="top" style="padding-bottom:4px;" nowrap>
+                                    <td class="value-small"><span
+                                            class="label-small">Signatur:</span> asdf <span
+                                            class="label-small">Vormerkdatum:</span> 13-11-2015
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                </table>
+            </form>
+        </td>
+    </tr>
+    <TR>
+        <TD><img
+                alt=""
+                src="/img_psi/2.0/gui/empty.gif"
+                width="1"
+                height="20"
+                border="0"></TD>
+    </TR>
+</table>
+
+
+<script type="text/javascript"
+        src="https://recommender.bibtip.de/js/bibtip_ub_mr.js"></script>
+
+
+<img src="https://dbspixel.hbz-nrw.de/count?id=AH004&amp;page=2" width="1" heigh
+     t="1">
+
+</BODY>
+</HTML>


### PR DESCRIPTION
The list of reservations was not parsed correctly.
I also created a `PicaOldTest` for `parseMediaList` and `parseResList` that uses HTML files of the account view we received from a bug reporter (with anonymized user data and changed book titles, signatures and IDs)